### PR TITLE
ParticleNet MD & 2018 Prelim WPs

### DIFF
--- a/src/Begin_Common.cc
+++ b/src/Begin_Common.cc
@@ -18,11 +18,6 @@ void Begin_Common()
     // Determine whether it is postprocessed NanoAOD or not
     Begin_Common_Determine_Is_Postprocessed(); 
     
-    //setup GRL
-    Begin_Common_Set_Run_List();
-
-    // Configure the gconf from NanoTools/NanoCORE/Config.h
-    Begin_Common_Set_Config();
 
     // The framework may run over NanoAOD directly or, it may run over VVVTree.
     // ana.run_VVVTree boolean determines this.
@@ -32,6 +27,11 @@ void Begin_Common()
     }
     else
     {
+        //setup GRL
+        Begin_Common_Set_Run_List();
+
+        // Configure the gconf from NanoTools/NanoCORE/Config.h
+        Begin_Common_Set_Config();
         Begin_Common_NanoAOD();
     }
 
@@ -71,6 +71,17 @@ void Begin_Common_Create_Branches()
     ana.tx.createBranch<bool>                 ("Common_HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL");
     ana.tx.createBranch<bool>                 ("Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ"); // Lowest unprescaled
     ana.tx.createBranch<bool>                 ("Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL");
+    //hadronic triggers
+    ana.tx.createBranch<bool>("Common_HLT_PFHT1050"); 
+    ana.tx.createBranch<bool>("Common_HLT_AK8PFJet500");
+    ana.tx.createBranch<bool>("Common_HLT_AK8PFJet380_TrimMass30");
+    ana.tx.createBranch<bool>("Common_HLT_AK8PFJet360_TrimMass30");
+    ana.tx.createBranch<bool>("Common_HLT_AK8PFJet400_TrimMass30");
+    ana.tx.createBranch<bool>("Common_HLT_AK8PFJet420_TrimMass30" );
+    ana.tx.createBranch<bool>("Common_HLT_AK8PFHT750_TrimMass50" );
+    ana.tx.createBranch<bool>("Common_HLT_AK8PFHT800_TrimMass50");
+    ana.tx.createBranch<bool>("Common_HLT_AK8PFHT850_TrimMass50" );
+    ana.tx.createBranch<bool>("Common_HLT_AK8PFHT900_TrimMass50" );
     // Summary triggers
     ana.tx.createBranch<bool>                 ("Common_HLT_DoubleEl");
     ana.tx.createBranch<bool>                 ("Common_HLT_MuEG");
@@ -176,9 +187,15 @@ void Begin_Common_Create_Branches()
     ana.tx.createBranch<vector<float>>        ("Common_fatjet_deepMD_T");      // Pt sorted selected fatjet FatJet_deepTagMD_TvsQCD (To access rest of the fatjet variables in NanoAOD)
     ana.tx.createBranch<vector<float>>        ("Common_fatjet_deep_T");        // Pt sorted selected fatjet FatJet_deepTag_TvsQCD (To access rest of the fatjet variables in NanoAOD)
     ana.tx.createBranch<vector<float>>        ("Common_fatjet_deepMD_bb");     // Pt sorted selected fatjet FatJet_deepTagMD_bbvsLight (To access rest of the fatjet variables in NanoAOD)
-    ana.tx.createBranch<vector<float>>        ("Common_fatjet_particleNet_W");     // Pt sorted selected fatjet FatJet_deepTagMD_bbvsLight (To access rest of the fatjet variables in NanoAOD)
-    ana.tx.createBranch<vector<float>>        ("Common_fatjet_particleNet_Z");     // Pt sorted selected fatjet FatJet_deepTagMD_bbvsLight (To access rest of the fatjet variables in NanoAOD)
-    ana.tx.createBranch<vector<float>>        ("Common_fatjet_particleNet_T");     // Pt sorted selected fatjet FatJet_deepTagMD_bbvsLight (To access rest of the fatjet variables in NanoAOD)
+    ana.tx.createBranch<vector<float>>        ("Common_fatjet_particleNetMD_W");     
+    ana.tx.createBranch<vector<float>>        ("Common_fatjet_particleNetMD_Xqq");     
+    ana.tx.createBranch<vector<float>>        ("Common_fatjet_particleNetMD_Xcc");     
+    ana.tx.createBranch<vector<float>>        ("Common_fatjet_particleNetMD_Xbb");     
+    ana.tx.createBranch<vector<float>>        ("Common_fatjet_particleNetMD_QCD");     
+    ana.tx.createBranch<vector<float>>        ("Common_fatjet_particleNet_QCD");    
+    ana.tx.createBranch<vector<float>>        ("Common_fatjet_particleNet_W");    
+    ana.tx.createBranch<vector<float>>        ("Common_fatjet_particleNet_Z");   
+    ana.tx.createBranch<vector<float>>        ("Common_fatjet_particleNet_T");  
     ana.tx.createBranch<vector<float>>        ("Common_fatjet_tau3");          // Pt sorted selected fatjet FatJet_deepTagMD_bbvsLight (To access rest of the fatjet variables in NanoAOD)
     ana.tx.createBranch<vector<float>>        ("Common_fatjet_tau2");          // Pt sorted selected fatjet FatJet_deepTagMD_bbvsLight (To access rest of the fatjet variables in NanoAOD)
     ana.tx.createBranch<vector<float>>        ("Common_fatjet_tau1");          // Pt sorted selected fatjet FatJet_deepTagMD_bbvsLight (To access rest of the fatjet variables in NanoAOD)
@@ -195,6 +212,7 @@ void Begin_Common_Create_Branches()
     ana.tx.createBranch<vector<LorentzVector>>("Common_fatjet_subjet0_p4");    // Pt sorted selected fatjet p4s
     ana.tx.createBranch<vector<LorentzVector>>("Common_fatjet_subjet1_p4");    // Pt sorted selected fatjet p4s
     ana.tx.createBranch<vector<int>>          ("Common_fatjet_WP");            // WP: 0: VLoose (5%), 1: Loose (2.5%), 2: Medium (1%), 3: Tight (0.5%)
+    ana.tx.createBranch<vector<int>>          ("Common_fatjet_WP_MD");            
     ana.tx.createBranch<vector<int>>          ("Common_fatjet_WP_antimasscut");// WP: 0: VLoose (5%), 1: Loose (2.5%), 2: Medium (1%), 3: Tight (0.5%)
     ana.tx.createBranch<vector<float>>        ("Common_fatjet_SFVLoose");      // single fatjet SF
     ana.tx.createBranch<vector<float>>        ("Common_fatjet_SFLoose");       // single fatjet SF

--- a/src/Begin_allHad.cc
+++ b/src/Begin_allHad.cc
@@ -2,16 +2,883 @@
 
 void Begin_allHad()
 {
-    //==============================================
-    // Begin_allHad:
-    // This function gets called prior to the event looping.
-    // This is where one declares variables, histograms, event selections for the category allHad.
-    //==============================================
+    //region 1 for 1Lep CR
+    if(ana.region == 1){
+        if(ana.run_VVVTree)
+            Begin_1L_VVVTree();
+        else   
+            Begin_1L_NanoAOD();
+    }
+    //signal selections
+    else{
+        if(ana.run_VVVTree)
+            Begin_allHad_VVVTree();
+        else
+            Begin_allHad_NanoAOD();
+    }
+}
 
-    // Create variables used in this category.
-    // Please follow the convention of <category>_<varname> structure.
-    // These are all filled in Process_allHad.cc
+void Begin_allHad_NanoAOD()
+{ 
+
+    //define skimming selections -- require 0 leptons and trigger and HT pass
+    ana.cutflow.getCut("CommonCut");
+    ana.cutflow.addCutToLastActiveCut("allHad", [&]() {
+
+        if( ana.tx.getBranchLazy<vector<int>>("Common_lep_pdgid").size() > 0) return false; 
+        if( ana.tx.getBranchLazy<vector<LorentzVector>>("Common_fatjet_p4").size() < 2) return false;
+        int nfj = 0;
+        for(unsigned int i=0; i < ana.tx.getBranchLazy<vector<LorentzVector>>("Common_fatjet_p4").size(); i++){
+            if( is_baseline_fatjet(i, true, false )) nfj++;
+        }
+        if(nfj < 2) return false;
+
+        return true;
+        }, [&]() { return  1;} );
+
+    ana.cutflow.addCutToLastActiveCut("allHad_trigger", [&]() {
+
+        if(   (ana.tx.getBranchLazy<bool>("Common_HLT_PFHT1050") || 
+               ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFJet500") || 
+               ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFJet360_TrimMass30") || 
+               ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFJet380_TrimMass30") || 
+               ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFJet400_TrimMass30") || 
+               ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFJet420_TrimMass30") || 
+               ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFHT750_TrimMass50") || 
+               ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFHT800_TrimMass50") || 
+               ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFHT850_TrimMass50") || 
+               ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFHT900_TrimMass50")  
+        )) return true;
+
+        return false;
+    }, [&]() { return 1; } );
+
+    ana.cutflow.addCutToLastActiveCut("allHad_HT", [&]() {
+
+        float HT = 0;
+        unsigned int nselect = 0;
+        for( unsigned int i=0; i < ana.tx.getBranchLazy<vector<LorentzVector>>("Common_jet_p4").size(); i++){
+            if ( is_baseline_jet(i) ){
+                HT+= ana.tx.getBranchLazy<vector<LorentzVector>>("Common_jet_p4")[i].Pt();
+            }
+        }
+        
+        for( unsigned int i=0; i < ana.tx.getBranchLazy<vector<LorentzVector>>("Common_fatjet_p4").size(); i++){
+            if( is_baseline_fatjet(i, true, false) ){
+                HT+= ana.tx.getBranchLazy<vector<LorentzVector>>("Common_fatjet_p4")[i].Pt();
+                nselect ++;
+            }
+        }
+
+        if( nselect != ana.tx.getBranchLazy<vector<int>>("Common_fatjet_idxs").size() ) return false;
+        if(HT > 1100) return true;
+        else return false;
+
+    }, [&]() { return 1; } );
+
     
+    ana.cutflow.bookCutflows(); 
+    
+}
+
+void Begin_1L_NanoAOD()
+{
+        //for 1L skimming -- 1 lepton and 1 fatjet
+    ana.cutflow.getCut("CommonCut");
+    ana.cutflow.addCutToLastActiveCut("oneLep", [&]() {
+
+        if( ana.tx.getBranchLazy<vector<int>>("Common_lep_pdgid").size() != 1) return false; 
+        if( ana.tx.getBranchLazy<vector<LorentzVector>>("Common_fatjet_p4").size() < 1) return false;
+        int nfj = 0;
+        for(unsigned int i=0; i < ana.tx.getBranchLazy<vector<LorentzVector>>("Common_fatjet_p4").size(); i++){
+            if( is_baseline_fatjet(i, false, false )) nfj++;
+        }
+        if(nfj < 1) return false;
+
+        return true;
+        }, [&]() { return  1;} );
+    
+    ana.cutflow.addCutToLastActiveCut("oneLep_trigger", [&]() {
+
+        if( abs(ana.tx.getBranchLazy<vector<int>>("Common_lep_pdgid")[0]) == 11 &&  ana.tx.getBranchLazy<bool>("Common_HLT_Ele32_WPTight") ) return true;
+        if( abs(ana.tx.getBranchLazy<vector<int>>("Common_lep_pdgid")[0]) == 13 &&  ana.tx.getBranchLazy<bool>("Common_HLT_IsoMu24") ) return true;
+
+        return false;
+        }, [&]() { return  1;} );
+
+    ana.cutflow.addCutToLastActiveCut("oneLep_HT", [&]() {
+
+        //Not going to include HT for now, since I want lower pT leptons, and that would bias this in a weird way
+        // float HT = 0;
+        // unsigned int nselect = 0;
+        // for( unsigned int i=0; i < ana.tx.getBranchLazy<vector<LorentzVector>>("Common_jet_p4").size(); i++){
+        //     if ( is_baseline_jet(i) ){
+        //         HT+= ana.tx.getBranchLazy<vector<LorentzVector>>("Common_jet_p4")[i].Pt();
+        //     }
+        // }
+        
+        // for( unsigned int i=0; i < ana.tx.getBranchLazy<vector<LorentzVector>>("Common_fatjet_p4").size(); i++){
+        //     if( is_baseline_fatjet(i, false, false) ){
+        //         HT+= ana.tx.getBranchLazy<vector<LorentzVector>>("Common_fatjet_p4")[i].Pt();
+        //         nselect ++;
+        //     }
+        // }
+
+        // HT+= ana.tx.getBranchLazy<vector<LorentzVector>>("Common_lep_p4")[0].Pt();
+
+        //just make sure that all the fatjets are good ones and move on
+        unsigned int nselect = 0;
+        for( unsigned int i=0; i < ana.tx.getBranchLazy<vector<LorentzVector>>("Common_fatjet_p4").size(); i++){
+            if( is_baseline_fatjet(i, false, false) ){
+                nselect ++;
+            }
+        }
+
+        if( nselect != ana.tx.getBranchLazy<vector<int>>("Common_fatjet_idxs").size() ) return false;
+
+        return true;
+        }, [&]() { return  1;} );
+        
+        ana.cutflow.bookCutflows();
+}
+
+
+
+void Begin_allHad_VVVTree()
+{
+   // float wgt = get_weight();
+    float wgt = 1.0;
+
+
+    //vector branches
+    ana.tx.createBranch<vector<float>>  ("allHad_Jet_pt");
+    ana.tx.createBranch<vector<float>>  ("allHad_Jet_eta");
+    ana.tx.createBranch<vector<float>>  ("allHad_Jet_phi");
+    ana.tx.createBranch<vector<float>>  ("allHad_Jet_M");
+    ana.tx.createBranch<vector<float>>  ("allHad_Jet_ID");
+    ana.tx.createBranch<vector<float>>  ("allHad_Jet_puid");
+    ana.tx.createBranch<vector<float>>  ("allHad_gen_vvvdecay_pdgid"); // for now these need to be floats bc addVecHistogram doesn't take ints
+    ana.tx.createBranch<vector<float>>  ("allHad_gen_vvvdecay_pt"); 
+    ana.tx.createBranch<vector<float>>  ("allHad_gen_vvv_pt"); 
+    ana.tx.createBranch<vector<float>>  ("allHad_gen_vvv_eta"); 
+    ana.tx.createBranch<vector<float>>  ("allHad_gen_pdgId");
+    
+    
+    // Single var branches
+    ana.tx.createBranch<float>  ("allHad_mindPhi_MetFJ");
+    ana.tx.createBranch<float>  ("allHad_genHT");
+    ana.tx.createBranch<float>  ("allHad_mVVV");
+    ana.tx.createBranch<float>  ("allHad_HT");
+    ana.tx.createBranch<float>  ("allHad_ST");
+    ana.tx.createBranch<float>  ("allHad_mVVV_reco");
+    ana.tx.createBranch<float>  ("allHad_ptVVV_reco");
+    ana.tx.createBranch<float>  ("allHad_mVVV_reco_nomet");
+    ana.tx.createBranch<float>  ("allHad_ptVVV_reco_nomet");
+    
+    ana.tx.createBranch<float>  ("allHad_fj_mVVV");
+    ana.tx.createBranch<float>  ("allHad_fj_HT");
+    ana.tx.createBranch<float>  ("allHad_fj_ST");
+    ana.tx.createBranch<float>  ("allHad_fj_mVVV_reco");
+    ana.tx.createBranch<float>  ("allHad_fj_ptVVV_reco");
+    ana.tx.createBranch<float>  ("allHad_fj_mVVV_reco_nomet");
+    ana.tx.createBranch<float>  ("allHad_fj_ptVVV_reco_nomet");
+    ana.tx.createBranch<float>  ("allHad_fj_mVVV_reco_nomet_SD");
+    ana.tx.createBranch<float>  ("allHad_fj_ptVVV_reco_nomet_SD");
+    
+    ana.tx.createBranch<float>  ("allHad_fj12_dPhi");
+    ana.tx.createBranch<float>  ("allHad_fj12_dEta");
+    ana.tx.createBranch<float>  ("allHad_fj12_dR");
+    ana.tx.createBranch<float>  ("allHad_fj23_dPhi");
+    ana.tx.createBranch<float>  ("allHad_fj23_dEta");
+    ana.tx.createBranch<float>  ("allHad_fj23_dR");
+    ana.tx.createBranch<float>  ("allHad_fj31_dPhi");
+    ana.tx.createBranch<float>  ("allHad_fj31_dEta");
+    ana.tx.createBranch<float>  ("allHad_fj31_dR");
+
+    ana.tx.createBranch<float>  ("allHad_FatJet_SF");
+    
+    ana.tx.createBranch<float>  ("allHad_v12_dPhi");
+    ana.tx.createBranch<float>  ("allHad_v12_dEta");
+    ana.tx.createBranch<float>  ("allHad_v12_dR");
+    ana.tx.createBranch<float>  ("allHad_v23_dPhi");
+    ana.tx.createBranch<float>  ("allHad_v23_dEta");
+    ana.tx.createBranch<float>  ("allHad_v23_dR");
+    ana.tx.createBranch<float>  ("allHad_v31_dPhi");
+    ana.tx.createBranch<float>  ("allHad_v31_dEta");
+    ana.tx.createBranch<float>  ("allHad_v31_dR");
+    
+    ana.tx.createBranch<float>  ("allHad_j12_mass");
+    ana.tx.createBranch<float>  ("allHad_j12_dPhi");
+    ana.tx.createBranch<float>  ("allHad_j12_dEta");
+    ana.tx.createBranch<float>  ("allHad_j12_dR");
+    ana.tx.createBranch<float>  ("allHad_j23_mass");
+    ana.tx.createBranch<float>  ("allHad_j23_dPhi");
+    ana.tx.createBranch<float>  ("allHad_j23_dEta");
+    ana.tx.createBranch<float>  ("allHad_j23_dR");
+    ana.tx.createBranch<float>  ("allHad_j31_mass");
+    ana.tx.createBranch<float>  ("allHad_j31_dPhi");
+    ana.tx.createBranch<float>  ("allHad_j31_dEta");
+    ana.tx.createBranch<float>  ("allHad_j31_dR");
+    
+    
+    ana.tx.createBranch<vector<float>>  ("allHad_genV_status");
+    ana.tx.createBranch<vector<float>>  ("allHad_FatJet_nMatchedQuarks");
+    
+    
+    
+    ana.tx.createBranch<int>  ("allHad_nGenLeps");
+    ana.tx.createBranch<int>  ("allHad_nGenQuarks");
+    ana.tx.createBranch<int>  ("allHad_nGenV");
+    ana.tx.createBranch<int>  ("allHad_nb_loose");
+    ana.tx.createBranch<int>  ("allHad_nb_medium");
+    ana.tx.createBranch<int>  ("allHad_nb_tight");
+    ana.tx.createBranch<int>  ("allHad_NFatJet_loose");
+    ana.tx.createBranch<int>  ("allHad_NFatJet_medium");
+    ana.tx.createBranch<int>  ("allHad_NFatJet_tight");
+    
+    //////////////////////////////////////////
+    // PRESELECTION
+    //////////////////////////////////////////
+
+    //at this point we've already skimmed
+    ana.cutflow.getCut("CommonCut");
+
+    const int eft_reweighting_idx = ana.eft_reweighting_idx;
+    std::cout << "eft index " << eft_reweighting_idx;
+    ana.cutflow.addCutToLastActiveCut("allHad_EFT", [&]() {
+        return true;
+        }, [&, eft_reweighting_idx]() { return  eft_reweighting_idx < 0 ? 1.0 : ana.tx.getBranchLazy<float>("Common_genWeight") * ana.tx.getBranchLazy<vector<float>>("Common_LHEReweightingWeight")[eft_reweighting_idx]; } );
+    
+
+    //This just adds in 1st fatjet pt > 500 signal cut
+    ana.cutflow.addCutToLastActiveCut("allHad_fixedHT", [&]() {
+        
+        float HT = 0;
+        unsigned int nselect = 0;
+
+        if( ! (ana.tx.getBranchLazy<bool>("Common_HLT_PFHT1050") || 
+               ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFJet500") || 
+               ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFJet360_TrimMass30") || 
+               ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFJet380_TrimMass30") || 
+               ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFJet400_TrimMass30") || 
+               ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFJet420_TrimMass30") || 
+               ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFHT750_TrimMass50") || 
+               ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFHT800_TrimMass50") || 
+               ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFHT850_TrimMass50") || 
+               ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFHT900_TrimMass50")  
+        )) return false;
+
+        for( unsigned int i=0; i < ana.tx.getBranchLazy<vector<LorentzVector>>("Common_jet_p4").size(); i++){
+            if(is_baseline_jet(i)){
+                HT+= ana.tx.getBranchLazy<vector<LorentzVector>>("Common_jet_p4")[i].Pt();
+            }
+        }
+
+        for( unsigned int ij =0; ij < ana.tx.getBranchLazy<vector<int>>("Common_fatjet_idxs").size(); ij++  ){
+            if(is_baseline_fatjet(ij, true, false)){
+                HT += ana.tx.getBranchLazy<vector<LorentzVector>>("Common_fatjet_p4")[ij].Pt();
+                nselect ++;
+            }
+        }
+
+        //want only events where the fatjets are all good
+        if( nselect != ana.tx.getBranchLazy<vector<int>>("Common_fatjet_idxs").size() ) return false;
+        if( HT < 1100) return false;
+        return true;
+        }, [&, wgt]() { return wgt; } );
+
+
+
+    //////////////////////////////////////////
+    // 1 MEDIUM 1 TIGHT
+    ////////////////////////////////////////// 
+
+    //build up to 1med1tight
+    ana.cutflow.getCut("allHad_fixedHT");
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_1med1tight_noB", [&]() {
+        if (ana.tx.getBranchLazy<int>("allHad_nb_medium") > 0) return false;
+        return true;
+        }, [&]() { return 1; } );
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_1med1tight_2j", [&]() {
+        if (ana.tx.getBranchLazy<vector<int>>("Common_fatjet_idxs").size() != 2 ) return false; 
+        return true;
+        }, [&]() { return 1; } );
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_1med1tight_2med", [&]() {
+        if( ! (is_baseline_fatjet(0, true, true) && is_baseline_fatjet(1, true, true)) ) return false;
+
+        if(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[0] < 2 ) return false;
+        if(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[1] < 2 ) return false;
+        
+        return true;
+        }, [&]() { return 1; } );
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_1med1tight", [&]() {
+        if( (ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[0] == 2 && ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[1] == 3)
+          ||(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[0] == 3 && ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[1] == 2)
+        ) return true;
+        return false;
+        }, [&]() { return 1; } );
+
+    ana.cutflow.getCut("allHad_2fj_1med1tight");
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_1med1tight_SRBin_1", [&]() {
+        if(ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco_nomet_SD") > 1000 && ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco_nomet_SD") <= 1500) return true;
+        return false;
+    }, [&]() { return 1; } );
+    
+    ana.cutflow.getCut("allHad_2fj_1med1tight");
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_1med1tight_SRBin_2", [&]() {
+        if(ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco_nomet_SD") > 1500 && ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco_nomet_SD") <= 3000) return true;
+        return false;
+    }, [&]() { return 1; } );
+
+    ana.cutflow.getCut("allHad_2fj_1med1tight");
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_1med1tight_SRBin_3", [&]() {
+        if(ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco_nomet_SD") > 3000 ) return true;
+        return false;
+    }, [&]() { return 1; } );
+
+    ana.cutflow.getCut("allHad_2fj_1med1tight");
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_1med1tight_ptVV", [&]() {
+        if (ana.tx.getBranchLazy<float>("allHad_fj_ptVVV_reco_nomet_SD") < 200) return false;
+        return true;
+        }, [&]() { return 1; } );
+    
+
+
+
+    //////////////////////////////////////////
+    // MSD SIDEBAND
+    //////////////////////////////////////////
+
+    //build up to mSD cut to understand data/MC disagreement
+    ana.cutflow.getCut("allHad_fixedHT");
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_mSD_sideband_noB", [&]() {
+        if (ana.tx.getBranchLazy<int>("allHad_nb_medium") > 0) return false;
+        return true;
+        }, [&]() { return 1; } );
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_mSD_sideband_2j", [&]() {
+        if (ana.tx.getBranchLazy<vector<int>>("Common_fatjet_idxs").size() != 2 ) return false; 
+        return true;
+        }, [&]() { return 1; } );
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_mSD_sideband_2tight", [&]() {
+        if( ! (is_baseline_fatjet(0, true, false) && is_baseline_fatjet(1, true, false)) ) return false;
+
+        if(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[0] != 3 ) return false;
+        if(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[1] != 3 ) return false;
+        
+        return true;
+        }, [&]() { return 1; } );
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_mSD_sideband", [&]() {
+        if(  (ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[0] < 65. && ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[0] > 40.)
+            ||  (ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[0] < 150. && ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[0] > 105.))
+            
+            {
+                if( (ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[1] < 65. && ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[1] > 40.)
+                ||  (ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[1] < 150. && ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[1] > 105.))
+                    return true;
+            }
+
+        return false;
+        }, [&]() { return 1; } );
+    
+    ana.cutflow.getCut("allHad_2fj_mSD_sideband");
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_mSD_sideband_SRBin_1", [&]() {
+        if(ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco_nomet_SD") > 1000 && ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco_nomet_SD") <= 1500) return true;
+        return false;
+    }, [&]() { return 1; } );
+    
+    ana.cutflow.getCut("allHad_2fj_mSD_sideband");
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_mSD_sideband_SRBin_2", [&]() {
+        if(ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco_nomet_SD") > 1500 && ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco_nomet_SD") <= 3000) return true;
+        return false;
+    }, [&]() { return 1; } );
+
+    ana.cutflow.getCut("allHad_2fj_mSD_sideband");
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_mSD_sideband_SRBin_3", [&]() {
+        if(ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco_nomet_SD") > 3000 ) return true;
+        return false;
+    }, [&]() { return 1; } );
+
+    ana.cutflow.getCut("allHad_2fj_mSD_sideband");
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_mSD_sideband_ptVV", [&]() {
+        if (ana.tx.getBranchLazy<float>("allHad_fj_ptVVV_reco_nomet_SD") < 200) return false;
+        return true;
+        }, [&]() { return 1; } );
+
+
+    
+
+    //////////////////////////////////////////
+    // 2/3 TIGHT FATJETS
+    //////////////////////////////////////////
+
+
+    ana.cutflow.getCut("allHad_fixedHT");
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_tight_2j", [&]() {
+        if (ana.tx.getBranchLazy<vector<int>>("Common_fatjet_idxs").size() !=2 ) return false;
+        return true;
+    }, [&]() { return 1; } );
+    
+    ana.cutflow.getCut("allHad_2fj_tight_2j");
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_tight_jetID", [&]() {
+        if( ! (is_baseline_fatjet(0, true, true) && is_baseline_fatjet(1, true, true)) ) return false;
+        return true;
+    }, [&]() { return 1; } );
+  
+    ana.cutflow.getCut("allHad_2fj_tight_jetID");
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_tight_1sttight", [&]() {
+        if(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[0] != 3 ) return false;
+        return true;
+    }, [&]() { return 1; } );
+    ana.cutflow.getCut("allHad_2fj_tight_1sttight");
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_tight", [&]() {
+        if(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[1] != 3 ) return false;
+        return true;
+    }, [&]() { return 1; } );
+
+
+    /*
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_tight", [&]() {
+
+        //if (ana.tx.getBranchLazy<float>("allHad_fj_ptVVV_reco_nomet_SD") < 200 ) return false;
+
+        //I want 2 fatjets, where both of them are tight
+        if (ana.tx.getBranchLazy<vector<int>>("Common_fatjet_idxs").size() !=2 ) return false;
+        //baseline fatjets passing first pt and mSD cuts
+        if( ! (is_baseline_fatjet(0, true, true) && is_baseline_fatjet(1, true, true)) ) return false;
+        
+        //2 tight fatjets
+        if(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[0] != 3 ) return false;
+        if(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[1] != 3 ) return false;
+
+        return true;
+        }, [&]() { return 1; } );*/
+
+
+    ana.cutflow.getCut("allHad_fixedHT");
+    ana.cutflow.addCutToLastActiveCut("allHad_3fj_tight", [&]() {
+        
+        //I want 3 fatjets, where all of them are tight
+        if (ana.tx.getBranchLazy<vector<int>>("Common_fatjet_idxs").size() !=3 ) return false;
+        //baseline fatjets passing first pt and mSD cuts
+        if( ! (is_baseline_fatjet(0, true, true) && is_baseline_fatjet(1, true, true) && is_baseline_fatjet(2, true, true)) ) return false;
+        
+        //3 tight fatjets
+        if(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[0] != 3 ) return false;
+        if(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[1] != 3 ) return false;
+        if(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[2] != 3 ) return false;
+
+        return true;
+        }, [&]() { return 1; } );
+
+    ana.cutflow.getCut("allHad_fixedHT");
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_ABCD", [&]() {
+
+        //I want 2 fatjets, where both of them are tight
+        if (ana.tx.getBranchLazy<vector<int>>("Common_fatjet_idxs").size() !=2 ) return false;
+        
+        // no b-jets
+        if (ana.tx.getBranchLazy<int>("allHad_nb_medium") > 0 ) return false;
+        //baseline fatjets passing first pt and mSD cuts
+        if( ! (is_baseline_fatjet(0, true, false) && is_baseline_fatjet(1, true, false)) ) return false;
+        
+
+        return true;
+        }, [&]() { return 1; } );
+
+    ana.cutflow.getCut("allHad_2fj_ABCD");
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_ABCD_A", [&]() {
+        //signal region -- 2 tight, signal mSD
+        if(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[0] != 3 ) return false;
+        if(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[1] != 3 ) return false;
+
+        if(  (ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[0] >= 65. && ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[0] <= 105.)
+          && (ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[1] >= 65. && ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[1] <= 105.))
+          return true;
+
+        return false;
+        }, [&]() { return 1; } );
+    
+    ana.cutflow.getCut("allHad_2fj_ABCD");
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_ABCD_B", [&]() {
+        //1st jet medium
+        if(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[0] != 2 ) return false;
+        if(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[1] != 3 ) return false;
+
+        if(  (ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[0] >= 65. && ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[0] <= 105.)
+          && (ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[1] >= 65. && ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[1] <= 105.))
+          return true;
+
+        return false;
+        }, [&]() { return 1; } );
+    
+    ana.cutflow.getCut("allHad_2fj_ABCD");
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_ABCD_C", [&]() {
+        //2nd jet low mSD
+        if(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[0] != 3 ) return false;
+        if(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[1] != 3 ) return false;
+
+        if(  (ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[0] >= 65. && ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[0] <= 105.)
+          && (ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[1] > 40. && ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[1] < 65.))
+          return true;
+
+        return false;
+        }, [&]() { return 1; } );
+    
+    ana.cutflow.getCut("allHad_2fj_ABCD");
+    ana.cutflow.addCutToLastActiveCut("allHad_2fj_ABCD_D", [&]() {
+        //2nd jet low mSD & 1st jet medium
+        if(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[0] != 2 ) return false;
+        if(ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[1] != 3 ) return false;
+
+        if(  (ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[0] >= 65. && ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[0] <= 105.)
+          && (ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[1] > 40. && ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[1] < 65.))
+          return true;
+
+        return false;
+        }, [&]() { return 1; } );
+    
+
+
+        
+
+
+    
+    //////////////////////////////////////////
+    // B-TAG CR
+    //////////////////////////////////////////   
+    // ana.cutflow.getCut("allHad_2fj_tight");
+    // ana.cutflow.addCutToLastActiveCut("allHad_CRb_2fj", [&]() {
+    //     if (ana.tx.getBranchLazy<int>("allHad_nb_medium") < 1 ) return false;
+    //     return true;
+    //     }, [&]() { return 1; } );
+
+    //////////////////////////////////////////
+    // SIGNAL REGION
+    //////////////////////////////////////////
+    ana.cutflow.getCut("allHad_2fj_tight");
+    ana.cutflow.addCutToLastActiveCut("allHad_ORTrigger_2fj", [&]() {
+        if (ana.tx.getBranchLazy<int>("allHad_nb_medium") > 0) return false;
+        return true;
+        }, [&]() { return 1; } );
+    
+    ana.cutflow.getCut("allHad_ORTrigger_2fj");
+    ana.cutflow.addCutToLastActiveCut("allHad_ORTrigger_2fj_SRBin_1", [&]() {
+        if(ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco_nomet_SD") > 1000 && ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco_nomet_SD") <= 1500) return true;
+        return false;
+    }, [&]() { return 1; } );
+    
+    ana.cutflow.getCut("allHad_ORTrigger_2fj");
+    ana.cutflow.addCutToLastActiveCut("allHad_ORTrigger_2fj_SRBin_2", [&]() {
+        if(ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco_nomet_SD") > 1500 && ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco_nomet_SD") <= 3000) return true;
+        return false;
+    }, [&]() { return 1; } );
+
+    ana.cutflow.getCut("allHad_ORTrigger_2fj");
+    ana.cutflow.addCutToLastActiveCut("allHad_ORTrigger_2fj_SRBin_3", [&]() {
+        if(ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco_nomet_SD") > 3000 ) return true;
+        return false;
+    }, [&]() { return 1; } );
+    
+    //////////////////////////////////////////
+    // 3 Fatjets
+    //////////////////////////////////////////
+    
+    ana.cutflow.getCut("allHad_3fj_tight");
+    ana.cutflow.addCutToLastActiveCut("allHad_ORTrigger_3fj", [&]() {
+        if (ana.tx.getBranchLazy<int>("allHad_nb_medium") > 0) return false;
+        return true;
+        }, [&]() { return 1; } );
+    
+    ana.cutflow.getCut("allHad_3fj_tight");
+    ana.cutflow.addCutToLastActiveCut("allHad_CRb_3fj", [&]() {
+        if (ana.tx.getBranchLazy<int>("allHad_nb_medium") < 1 ) return false;
+        return true;
+        }, [&]() { return 1; } );
+   
+   
+    
+    vector<float> SR_bins{0,1000,1500, 3500, 8000};
+
+    RooUtil::Histograms hists_allHad;
+
+    //single value histograms
+    hists_allHad.addHistogram("NJets"            ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<vector<float>>("allHad_Jet_pt").size()    ; } );
+    hists_allHad.addHistogram("NLeps"            ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<vector<int>>("Common_lep_pdgid").size()   ; } );
+    hists_allHad.addHistogram("NGenFatJets"       ,  10,   0,   10, [&]() { return      ana.tx.getBranchLazy<vector<LorentzVector>>("Common_genFatJet_p4").size()   ; } );
+    hists_allHad.addHistogram("NFatJets"         ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_pt").size() ; } );
+    hists_allHad.addHistogram("NW"               ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<int>("Common_n_W") ; } );
+    //hists_allHad.addHistogram("gen_vvvdecay_n"               ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<vector<int>>("Common_gen_vvvdecay_idx").size() ; } );
+    hists_allHad.addHistogram("n_b_loose"          ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<int>("allHad_nb_loose") ; } );
+    hists_allHad.addHistogram("n_b_medium"          ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<int>("allHad_nb_medium") ; } );
+    hists_allHad.addHistogram("n_b_tight"          ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<int>("allHad_nb_tight") ; } );
+
+    hists_allHad.addHistogram("nFatJet_loose"          ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<int>("allHad_NFatJet_loose") ; } );
+    hists_allHad.addHistogram("nFatJet_medium"          ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<int>("allHad_NFatJet_medium") ; } );
+    hists_allHad.addHistogram("nFatJet_tight"          ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<int>("allHad_NFatJet_tight") ; } );  
+
+    hists_allHad.addHistogram("MET"              ,  40,   0,    800, [&]() { return    ana.tx.getBranch<LorentzVector>  ("Common_met_p4").Pt(); } );
+
+    hists_allHad.addHistogram("MET_phi"              ,  40,   -4,    4, [&]() { return    ana.tx.getBranch<LorentzVector>  ("Common_met_p4").Phi(); } );
+    hists_allHad.addHistogram("METFJ_dPhi_min"       ,  40,   0,    4, [&]() { return    ana.tx.getBranch<float>  ("allHad_mindPhi_MetFJ"); } );
+    ///hists_allHad.addHistogram("mVVV"               ,  60,   0,    5000, [&]() { return    ana.tx.getBranch<float>  ("allHad_mVVV"); } );
+    hists_allHad.addHistogram("genHT"            ,  40,   0,    5000, [&]() { return    ana.tx.getBranch<float>  ("allHad_genHT"); } );
+    hists_allHad.addHistogram("HT"               ,  40,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_HT"); } );
+    hists_allHad.addHistogram("ST"               ,  40,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_ST"); } );
+    hists_allHad.addHistogram("mVVV_reco"               ,  60,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_mVVV_reco"); } );
+    hists_allHad.addHistogram("ptVVV_reco"               ,  60,   0,    800, [&]() { return    ana.tx.getBranch<float>  ("allHad_ptVVV_reco"); } );
+    hists_allHad.addHistogram("mVVV_reco_nomet"               ,  60,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_mVVV_reco_nomet"); } );
+    hists_allHad.addHistogram("ptVVV_reco_nomet"               ,  60,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_ptVVV_reco_nomet"); } );
+    
+    hists_allHad.addHistogram("HT_fj"               ,  40,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_HT"); } );
+    hists_allHad.addHistogram("ST_fj"               ,  40,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_ST"); } );
+    hists_allHad.addHistogram("mVVV_reco_fj"               ,  60,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_mVVV_reco"); } );
+    hists_allHad.addHistogram("ptVVV_reco_fj"               ,  60,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco"); } );
+    hists_allHad.addHistogram("mVVV_reco_nomet_fj"               ,  60,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_mVVV_reco_nomet"); } );
+    hists_allHad.addHistogram("ptVVV_reco_nomet_fj"               ,  60,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco_nomet"); } );
+    hists_allHad.addHistogram("mVVV_reco_nomet_fj_SD"               ,  60,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_mVVV_reco_nomet_SD"); } );
+    hists_allHad.addHistogram("ptVVV_reco_nomet_fj_SD"               ,  60,   0,    800, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco_nomet_SD"); } );
+    
+    hists_allHad.addHistogram("mVVV_SRbins"                        , SR_bins, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_mVVV_reco_nomet_SD"); } );
+
+    //hists_allHad.addHistogram("gen_vvv_pt0"       ,  20,   0,    2000,  [&]() { return (ana.tx.getBranch<vector<float>>("allHad_gen_vvv_pt").size() > 0) ?     ana.tx.getBranch<vector<float>>  ("allHad_gen_vvv_pt")[0] : -999; } );
+    //hists_allHad.addHistogram("gen_vvv_eta0"       ,  20,  0,    3,  [&]() { return   (ana.tx.getBranch<vector<float>>("allHad_gen_vvv_eta").size() > 0) ?   ana.tx.getBranch<vector<float>>  ("allHad_gen_vvv_eta")[0] : -999; } );
+    /*
+    hists_allHad.add2DHistogram("genHT", 60,   0,    3000, "HT", 40,   0,    3000, [&]() { return ana.tx.getBranch<float>  ("allHad_genHT");}, [&]() { return ana.tx.getBranch<float>  ("allHad_HT"); } );
+    hists_allHad.add2DHistogram("Njets", 6,   0,    6, "NFatjets", 6,   0,    6, [&]() { return ana.tx.getBranchLazy<vector<float>>("allHad_Jet_pt").size();}, [&]() { return ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_pt").size(); } );
+
+    // compare to MET 
+    //hists_allHad.add2DHistogram("mVVV", 60,   0,    3000,      "MET", 40,   0,    2000, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV");}, [&]() { return ana.tx.getBranch<float>  ("allHad_MET"); } );
+    //hists_allHad.add2DHistogram("HT", 60,   0,    5000,        "MET", 40,   0,    2000, [&]() { return ana.tx.getBranch<float>  ("allHad_HT");}, [&]() { return ana.tx.getBranch<float>  ("allHad_MET"); } );
+    //hists_allHad.add2DHistogram("mVVV_reco", 60,   0,    5000, "MET", 40,   0,    2000, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_MET"); } );
+    hists_allHad.add2DHistogram("mVVV", 60,   0,    5000,      "ST", 60,   0,    5000, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV");}, [&]() { return ana.tx.getBranch<float>  ("allHad_ST"); } );
+    hists_allHad.add2DHistogram("mVVV_reco", 60,   0,    5000, "ST", 60,   0,    5000, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_ST"); } );
+    
+    //event vars with all jets
+    hists_allHad.add2DHistogram("mVVV", 60,   0,    5000,       "HT", 60,   0,    5000, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV");}, [&]() { return ana.tx.getBranch<float>  ("allHad_HT"); } );
+    hists_allHad.add2DHistogram("mVVV_reco", 60,   0,    5000,  "HT", 60,   0,    5000, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_HT"); } );
+    hists_allHad.add2DHistogram("ptVVV_reco", 60,   0,    5000, "HT", 60,   0,    5000, [&]() { return ana.tx.getBranch<float>  ("allHad_ptVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_HT"); } );
+    hists_allHad.add2DHistogram("mVVV", 60,   0,    5000,       "mVVV_reco", 60,   0,    5000, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV");}, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV_reco"); } );
+    hists_allHad.add2DHistogram("mVVV_reco", 60,   0,    5000, "ptVVV_reco", 60,   0,    5000, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_ptVVV_reco"); } );
+    
+    //event vars with fatjets
+
+
+    //angular stuff
+    hists_allHad.add2DHistogram("FatJet12_dPhi", 60,   0,    4, "FatJet12_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dEta"); } );
+    hists_allHad.add2DHistogram("FatJet23_dPhi", 60,   0,    4, "FatJet23_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj23_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj23_dEta"); } );
+    hists_allHad.add2DHistogram("FatJet31_dPhi", 60,   0,    4, "FatJet31_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj31_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj31_dEta"); } );
+    hists_allHad.add2DHistogram("FatJet12_dR", 60,   0,    5, "FatJet23_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dR");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj23_dR"); } );
+    hists_allHad.add2DHistogram("FatJet12_dR", 60,   0,    5, "FatJet31_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dR");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj31_dR"); } );
+    hists_allHad.add2DHistogram("FatJet31_dR", 60,   0,    5, "FatJet23_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_fj31_dR");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj23_dR"); } );  
+    hists_allHad.add2DHistogram("FatJet12_dPhi", 60,   0,    4, "FatJet23_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj23_dPhi"); } );
+    hists_allHad.add2DHistogram("FatJet12_dPhi", 60,   0,    4, "FatJet31_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj31_dPhi"); } );
+    hists_allHad.add2DHistogram("FatJet31_dPhi", 60,   0,    4, "FatJet23_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj31_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj23_dPhi"); } );  
+    
+    
+    hists_allHad.add2DHistogram("ptVVV_reco_fj", 60,   0,    1000, "FatJet12_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dPhi"); } );
+    hists_allHad.add2DHistogram("ptVVV_reco_fj", 60,   0,    1000, "FatJet12_dPhi_zoom", 60,   2,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dPhi"); } );
+    hists_allHad.add2DHistogram("ptVVV_reco_fj", 60,   0,    1000, "FatJet12_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dEta"); } );   
+    hists_allHad.add2DHistogram("ptVVV_reco_fj", 60,   0,    1000, "FatJet12_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dR"); } );
+    hists_allHad.add2DHistogram("ptVVV_reco", 60,   0,    1000, "FatJet12_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_ptVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dPhi"); } );
+    hists_allHad.add2DHistogram("ptVVV_reco", 60,   0,    1000, "FatJet12_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_ptVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dEta"); } );   
+    hists_allHad.add2DHistogram("ptVVV_reco", 60,   0,    1000, "FatJet12_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_ptVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dR"); } );
+    hists_allHad.add2DHistogram("mVVV_reco_fj", 60,   0,    5000, "FatJet12_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dPhi"); } );
+    hists_allHad.add2DHistogram("mVVV_reco_fj", 60,   0,    5000, "FatJet12_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dEta"); } );   
+    hists_allHad.add2DHistogram("mVVV_reco_fj", 60,   0,    5000, "FatJet12_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dR"); } );
+    hists_allHad.add2DHistogram("mVVV_reco", 60,   0,    5000, "FatJet12_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dPhi"); } );
+    hists_allHad.add2DHistogram("mVVV_reco", 60,   0,    5000, "FatJet12_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dEta"); } );   
+    hists_allHad.add2DHistogram("mVVV_reco", 60,   0,    5000, "FatJet12_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dR"); } );
+
+
+
+    hists_allHad.add2DHistogram("fatjet_1_eta", 60,   -3,    3, "fatjet_2_eta", 60,   -3,    3, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 1) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_eta")[0] : -999;}, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 1) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_eta")[1] : -999; } );
+    hists_allHad.add2DHistogram("fatjet_1_phi", 60,   -4,    4, "fatjet_2_phi", 60,   -4,    4, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 1) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_phi")[0] : -999;}, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 1) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_phi")[1] : -999; } );
+
+    hists_allHad.add2DHistogram("fatjet_2_eta", 60,   -3,    3, "fatjet_3_eta", 60,   -3,    3, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 2) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_eta")[1] : -999;}, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 2) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_eta")[2] : -999; } );
+    hists_allHad.add2DHistogram("fatjet_3_eta", 60,   -3,    3, "fatjet_1_eta", 60,   -3,    3, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 2) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_eta")[2] : -999;}, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 2) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_eta")[1] : -999; } );
+    hists_allHad.add2DHistogram("fatjet_2_phi", 60,   -4,    4, "fatjet_3_phi", 60,   -4,    4, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 2) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_phi")[1] : -999;}, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 2) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_phi")[2] : -999; } );
+    hists_allHad.add2DHistogram("fatjet_3_phi", 60,   -4,    4, "fatjet_1_phi", 60,   -4,    4, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 2) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_phi")[2] : -999;}, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 2) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_phi")[1] : -999; } );
+    
+    hists_allHad.add2DHistogram("jet12_mass", 60,   0,    1000, "jet12_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_j12_mass");}, [&]() { return ana.tx.getBranch<float>  ("allHad_j12_dR"); } );
+    hists_allHad.add2DHistogram("jet23_mass", 60,   0,    1000, "jet23_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_j23_mass");}, [&]() { return ana.tx.getBranch<float>  ("allHad_j23_dR"); } );
+    hists_allHad.add2DHistogram("jet31_mass", 60,   0,    1000, "jet31_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_j31_mass");}, [&]() { return ana.tx.getBranch<float>  ("allHad_j31_dR"); } );
+    
+    
+    */
+
+    hists_allHad.addHistogram("FatJet12_dPhi"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_fj12_dPhi"); } );
+    hists_allHad.addHistogram("FatJet12_dPhi_zoom"   ,  60,   2.5,    3.2, [&]() { return      ana.tx.getBranch<float>("allHad_fj12_dPhi"); } );
+    hists_allHad.addHistogram("FatJet12_dEta"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_fj12_dEta"); } );
+    hists_allHad.addHistogram("FatJet12_dR"     ,  60,   0,    5, [&]() { return      ana.tx.getBranch<float>("allHad_fj12_dR"); } );
+    hists_allHad.addHistogram("FatJet23_dPhi"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_fj23_dPhi"); } );
+    hists_allHad.addHistogram("FatJet23_dPhi_zoom"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_fj23_dPhi"); } );
+    hists_allHad.addHistogram("FatJet23_dEta"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_fj23_dEta"); } );
+    hists_allHad.addHistogram("FatJet23_dR"     ,  60,   0,    5, [&]() { return      ana.tx.getBranch<float>("allHad_fj23_dR"); } );
+    hists_allHad.addHistogram("FatJet31_dPhi"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_fj31_dPhi"); } );
+    hists_allHad.addHistogram("FatJet31_dPhi_zoom"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_fj31_dPhi"); } );
+    hists_allHad.addHistogram("FatJet31_dEta"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_fj31_dEta"); } );
+    hists_allHad.addHistogram("FatJet31_dR"     ,  60,   0,    5, [&]() { return      ana.tx.getBranch<float>("allHad_fj31_dR"); } );
+
+
+    
+    hists_allHad.addHistogram("jet12_mass"          ,  60,   0,    500, [&]() { return  ana.tx.getBranch<float>("allHad_j12_mass") ; } );
+    hists_allHad.addHistogram("jet23_mass"          ,  60,   0,    500, [&]() { return  ana.tx.getBranch<float>("allHad_j23_mass") ; } );
+    hists_allHad.addHistogram("jet31_mass"          ,  60,   0,    500, [&]() { return  ana.tx.getBranch<float>("allHad_j31_mass") ; } );
+    
+    hists_allHad.addHistogram("FatJet_pt_0"          ,  40,   0,    2000, [&]() { return      (ana.tx.getBranch<vector<LorentzVector>>("Common_fatjet_p4").size() > 0) ? ana.tx.getBranch<vector<LorentzVector>>("Common_fatjet_p4")[0].Pt() : -999 ; } );
+    hists_allHad.addHistogram("FatJet_pt_1"          ,  40,   0,    2000, [&]() { return      (ana.tx.getBranch<vector<LorentzVector>>("Common_fatjet_p4").size() > 1) ? ana.tx.getBranch<vector<LorentzVector>>("Common_fatjet_p4")[1].Pt() : -999 ; } );
+    hists_allHad.addHistogram("FatJet_pt_2"          ,  40,   0,    2000, [&]() { return      (ana.tx.getBranch<vector<LorentzVector>>("Common_fatjet_p4").size() > 2) ? ana.tx.getBranch<vector<LorentzVector>>("Common_fatjet_p4")[2].Pt() : -999 ; } );
+    
+    
+    hists_allHad.addHistogram("FatJet_eta_0"          ,  20,   -3,    3, [&]() { return      (ana.tx.getBranch<vector<LorentzVector>>("Common_fatjet_p4").size() > 0) ? ana.tx.getBranch<vector<LorentzVector>>("Common_fatjet_p4")[0].Eta() : -999 ; } );
+    hists_allHad.addHistogram("FatJet_eta_1"          ,  20,   -3,    3, [&]() { return      (ana.tx.getBranch<vector<LorentzVector>>("Common_fatjet_p4").size() > 1) ? ana.tx.getBranch<vector<LorentzVector>>("Common_fatjet_p4")[1].Eta() : -999 ; } );
+    hists_allHad.addHistogram("FatJet_eta_2"          ,  20,   -3,    3, [&]() { return      (ana.tx.getBranch<vector<LorentzVector>>("Common_fatjet_p4").size() > 2) ? ana.tx.getBranch<vector<LorentzVector>>("Common_fatjet_p4")[2].Eta() : -999 ; } );
+    
+    // hists_allHad.addHistogram("FatJet_M_0"          ,  40,   0,    200, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_M").size() > 0) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_M")[0] : -999 ; } );
+    // hists_allHad.addHistogram("FatJet_M_1"          ,  40,   0,    200, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_M").size() > 1) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_M")[1] : -999 ; } );
+    // hists_allHad.addHistogram("FatJet_M_2"          ,  40,   0,    200, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_M").size() > 2) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_M")[2] : -999 ; } );
+
+    
+    // hists_allHad.addHistogram("FatJet_tau1_0"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau1").size() > 0) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau1")[0] : -999 ; } );
+    // hists_allHad.addHistogram("FatJet_tau1_1"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau1").size() > 1) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau1")[1] : -999 ; } );
+    // hists_allHad.addHistogram("FatJet_tau1_2"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau1").size() > 2) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau1")[2] : -999 ; } );
+    
+    // hists_allHad.addHistogram("FatJet_tau2_0"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau2").size() > 0) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau2")[0] : -999 ; } );
+    // hists_allHad.addHistogram("FatJet_tau2_1"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau2").size() > 1) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau2")[1] : -999 ; } );
+    // hists_allHad.addHistogram("FatJet_tau2_2"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau2").size() > 2) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau2")[2] : -999 ; } );
+    
+    // hists_allHad.addHistogram("FatJet_tau3_0"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau3").size() > 0) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau3")[0] : -999 ; } );
+    // hists_allHad.addHistogram("FatJet_tau3_1"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau3").size() > 1) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau3")[1] : -999 ; } );
+    // hists_allHad.addHistogram("FatJet_tau3_2"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau3").size() > 2) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau3")[2] : -999 ; } );
+    
+    
+    hists_allHad.addHistogram("FatJet_tau21_0"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_tau21").size() > 0) ? ana.tx.getBranch<vector<float>>("Common_fatjet_tau21")[0] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_tau21_1"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_tau32").size() > 1) ? ana.tx.getBranch<vector<float>>("Common_fatjet_tau21")[1] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_tau21_2"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_tau32").size() > 2) ? ana.tx.getBranch<vector<float>>("Common_fatjet_tau21")[2] : -999 ; } );
+
+    hists_allHad.addHistogram("FatJet_tau32_0"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_tau32").size() > 0) ? ana.tx.getBranch<vector<float>>("Common_fatjet_tau32")[0] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_tau32_1"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_tau32").size() > 1) ? ana.tx.getBranch<vector<float>>("Common_fatjet_tau32")[1] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_tau32_2"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_tau32").size() > 2) ? ana.tx.getBranch<vector<float>>("Common_fatjet_tau32")[2] : -999 ; } );
+    
+    hists_allHad.addHistogram("FatJet_deepMD_W_0"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_deepMD_W").size() > 0) ? ana.tx.getBranch<vector<float>>("Common_fatjet_deepMD_W")[0] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_deepMD_W_1"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_deepMD_W").size() > 1) ? ana.tx.getBranch<vector<float>>("Common_fatjet_deepMD_W")[1] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_deepMD_W_2"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_deepMD_W").size() > 2) ? ana.tx.getBranch<vector<float>>("Common_fatjet_deepMD_W")[2] : -999 ; } );
+    
+    hists_allHad.addHistogram("FatJet_deepMD_Z_0"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_deepMD_W").size() > 0) ? ana.tx.getBranch<vector<float>>("Common_fatjet_deepMD_W")[0] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_deepMD_Z_1"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_deepMD_Z").size() > 1) ? ana.tx.getBranch<vector<float>>("Common_fatjet_deepMD_W")[1] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_deepMD_Z_2"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_deepMD_Z").size() > 2) ? ana.tx.getBranch<vector<float>>("Common_fatjet_deepMD_W")[2] : -999 ; } );
+    
+    hists_allHad.addHistogram("FatJet_deepMD_T_0"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_deepMD_T").size() > 0) ? ana.tx.getBranch<vector<float>>("Common_fatjet_deepMD_T")[0] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_deepMD_T_1"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_deepMD_T").size() > 1) ? ana.tx.getBranch<vector<float>>("Common_fatjet_deepMD_T")[1] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_deepMD_T_2"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_deepMD_T").size() > 2) ? ana.tx.getBranch<vector<float>>("Common_fatjet_deepMD_T")[2] : -999 ; } );
+    
+    hists_allHad.addHistogram("FatJet_particleNet_W_0"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_particleNet_W").size() > 0) ? ana.tx.getBranch<vector<float>>("Common_fatjet_particleNet_W")[0] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_particleNet_W_1"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_particleNet_W").size() > 1) ? ana.tx.getBranch<vector<float>>("Common_fatjet_particleNet_W")[1] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_particleNet_W_2"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_particleNet_W").size() > 2) ? ana.tx.getBranch<vector<float>>("Common_fatjet_particleNet_W")[2] : -999 ; } );
+    
+    hists_allHad.addHistogram("FatJet_particleNet_Z_0"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_particleNet_W").size() > 0) ? ana.tx.getBranch<vector<float>>("Common_fatjet_particleNet_W")[0] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_particleNet_Z_1"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_particleNet_Z").size() > 1) ? ana.tx.getBranch<vector<float>>("Common_fatjet_particleNet_W")[1] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_particleNet_Z_2"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_particleNet_Z").size() > 2) ? ana.tx.getBranch<vector<float>>("Common_fatjet_particleNet_W")[2] : -999 ; } );
+    
+    hists_allHad.addHistogram("FatJet_particleNet_T_0"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_particleNet_T").size() > 0) ? ana.tx.getBranch<vector<float>>("Common_fatjet_particleNet_T")[0] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_particleNet_T_1"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_particleNet_T").size() > 1) ? ana.tx.getBranch<vector<float>>("Common_fatjet_particleNet_T")[1] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_particleNet_T_2"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_particleNet_T").size() > 2) ? ana.tx.getBranch<vector<float>>("Common_fatjet_particleNet_T")[2] : -999 ; } );
+
+
+    hists_allHad.addHistogram("FatJet_msoftdrop_0"          ,  40,   0,    200, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_msoftdrop").size() > 0) ? ana.tx.getBranch<vector<float>>("Common_fatjet_msoftdrop")[0] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_msoftdrop_1"          ,  40,   0,    200, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_msoftdrop").size() > 1) ? ana.tx.getBranch<vector<float>>("Common_fatjet_msoftdrop")[1] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_msoftdrop_2"          ,  40,   0,    200, [&]() { return      (ana.tx.getBranch<vector<float>>("Common_fatjet_msoftdrop").size() > 2) ? ana.tx.getBranch<vector<float>>("Common_fatjet_msoftdrop")[2] : -999 ; } );
+    
+    hists_allHad.addHistogram("Jet_pt_0"          ,  40,   0,    2000, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_Jet_pt").size() > 0) ? ana.tx.getBranch<vector<float>>("allHad_Jet_pt")[0] : -999 ; } );
+    hists_allHad.addHistogram("Jet_pt_1"          ,  40,   0,    2000, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_Jet_pt").size() > 1) ? ana.tx.getBranch<vector<float>>("allHad_Jet_pt")[1] : -999 ; } );
+    hists_allHad.addHistogram("Jet_pt_2"          ,  40,   0,    2000, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_Jet_pt").size() > 2) ? ana.tx.getBranch<vector<float>>("allHad_Jet_pt")[2] : -999 ; } );
+    hists_allHad.addHistogram("Jet_pt_3"          ,  40,   0,    2000, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_Jet_pt").size() > 3) ? ana.tx.getBranch<vector<float>>("allHad_Jet_pt")[3] : -999; } );
+    
+    hists_allHad.addHistogram("Jet_eta_0"          ,  20,   -3,    3, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_Jet_eta").size() > 0) ? ana.tx.getBranch<vector<float>>("allHad_Jet_eta")[0] : -999 ; } );
+    hists_allHad.addHistogram("Jet_eta_1"          ,  20,   -3,    3, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_Jet_eta").size() > 1) ? ana.tx.getBranch<vector<float>>("allHad_Jet_eta")[1] : -999 ; } );
+    hists_allHad.addHistogram("Jet_eta_2"          ,  20,   -3,    3, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_Jet_eta").size() > 2) ? ana.tx.getBranch<vector<float>>("allHad_Jet_eta")[2] : -999 ; } );
+    hists_allHad.addHistogram("Jet_eta_3"          ,  20,   -3,    3, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_Jet_eta").size() > 3) ? ana.tx.getBranch<vector<float>>("allHad_Jet_eta")[3] : -999; } );
+    
+    //ABCD Method?
+    hists_allHad.add2DHistogram("mSD_0",  10,   40,     150,  "mSD_1",  10,   40,     150,   [&]() { return ana.tx.getBranch<vector<float>>  ("Common_fatjet_msoftdrop")[0];}, [&]() { return ana.tx.getBranch<vector<float>>  ("Common_fatjet_msoftdrop")[1]; } );
+    //hists_allHad.add2DHistogram("mSD_0_high", 10,   105,    150, "mSD_1_high", 10,   105,    150, [&]() { return ana.tx.getBranch<vector<float>>  ("allHad_FatJet_msoftdrop")[0];}, [&]() { return ana.tx.getBranch<vector<float>>  ("allHad_FatJet_msoftdrop")[1]; } );
+    //hists_allHad.add2DHistogram("mSD_0_SR",   10,   65,     105, "mSD_1_SR",   10,   65,     105, [&]() { return ana.tx.getBranch<vector<float>>  ("allHad_FatJet_msoftdrop")[0];}, [&]() { return ana.tx.getBranch<vector<float>>  ("allHad_FatJet_msoftdrop")[1]; } );
+
+    hists_allHad.add2DHistogram("WTag_0",     10,   0.5,     1, "WTag_1",      10,  0.5,     1, [&]() { return ana.tx.getBranch<vector<float>>  ("Common_fatjet_particleNet_W")[0];}, [&]() { return ana.tx.getBranch<vector<float>>  ("Common_fatjet_particleNet_W")[1]; } );
+    hists_allHad.add2DHistogram("WTag_0",     10,   0.5,     1, "mSD_0",       20,  40,     150, [&]() { return ana.tx.getBranch<vector<float>>  ("Common_fatjet_particleNet_W")[0];}, [&]() { return ana.tx.getBranch<vector<float>>  ("Common_fatjet_msoftdrop")[0]; } );
+    hists_allHad.add2DHistogram("WTag_1",     10,   0.5,     1, "mSD_1",       20,  40,     150, [&]() { return ana.tx.getBranch<vector<float>>  ("Common_fatjet_particleNet_W")[1];}, [&]() { return ana.tx.getBranch<vector<float>>  ("Common_fatjet_msoftdrop")[1]; } );
+    hists_allHad.add2DHistogram("WTag_0",     10,   0.5,     1, "mSD_1",       20,  40,     150, [&]() { return ana.tx.getBranch<vector<float>>  ("Common_fatjet_particleNet_W")[0];}, [&]() { return ana.tx.getBranch<vector<float>>  ("Common_fatjet_msoftdrop")[1]; } );
+    hists_allHad.add2DHistogram("WTag_1",     10,   0.5,     1, "mSD_0",       20,  40,     150, [&]() { return ana.tx.getBranch<vector<float>>  ("Common_fatjet_particleNet_W")[1];}, [&]() { return ana.tx.getBranch<vector<float>>  ("Common_fatjet_msoftdrop")[0]; } );
+
+
+    /* GEN STUFF
+    hists_allHad.addHistogram("genV_status_0"          ,  10,   0,    10, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_genV_status").size() > 0) ? ana.tx.getBranch<vector<float>>("allHad_genV_status")[0] : -999 ; } );
+    hists_allHad.addHistogram("genV_status_1"          ,  10,   0,    10, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_genV_status").size() > 1) ? ana.tx.getBranch<vector<float>>("allHad_genV_status")[1] : -999 ; } );
+    hists_allHad.addHistogram("genV_status_2"          ,  10,   0,    10, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_genV_status").size() > 2) ? ana.tx.getBranch<vector<float>>("allHad_genV_status")[2] : -999 ; } );
+    
+    
+    hists_allHad.addHistogram("NGenLeptons"       ,  10,   0,   10, [&]() { return      ana.tx.getBranchLazy<int>("allHad_nGenLeps")   ; } );
+    hists_allHad.addHistogram("NGenQuarks"       ,  10,   0,   10, [&]() { return      ana.tx.getBranchLazy<int>("allHad_nGenQuarks")   ; } );
+    hists_allHad.addHistogram("NGenV"       ,  10,   0,   10, [&]() { return      ana.tx.getBranchLazy<int>("allHad_nGenV")   ; } );
+    hists_allHad.addHistogram("FatJet_0_NMatchedQuarks"       ,  10,   0,   10, [&]() { return  (ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_nMatchedQuarks").size() > 0 ) ?    ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_nMatchedQuarks")[0] : -999  ; } );
+    hists_allHad.addHistogram("FatJet_1_NMatchedQuarks"       ,  10,   0,   10, [&]() { return  (ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_nMatchedQuarks").size() > 1 ) ?    ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_nMatchedQuarks")[1] : -999  ; } );
+    hists_allHad.addHistogram("FatJet_2_NMatchedQuarks"       ,  10,   0,   10, [&]() { return  (ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_nMatchedQuarks").size() > 2 ) ?    ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_nMatchedQuarks")[2] : -999  ; } );
+    //hists_allHad.addHistogram("NGenJets"       ,  10,   0,   10, [&]() { return      ana.tx.getBranchLazy<vector<LorentzVector>>("Common_genJet_p4").size()   ; } );
+    
+    hists_allHad.addVecHistogram("gen_vvvdecay_pdgid"       ,  20,   0,    20,  [&]() { return      ana.tx.getBranch<vector<float>>  ("allHad_gen_vvvdecay_pdgid"); } );
+    
+    hists_allHad.add2DHistogram("genV12_dPhi", 60,   0,    4, "genV12_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v12_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_v12_dEta"); } );
+    hists_allHad.add2DHistogram("genV23_dPhi", 60,   0,    4, "genV23_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v23_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_v23_dEta"); } );
+    hists_allHad.add2DHistogram("genV31_dPhi", 60,   0,    4, "genV31_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v31_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_v31_dEta"); } );
+    hists_allHad.add2DHistogram("genV12_dR", 60,   0,    5, "genV23_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_v12_dR");}, [&]() { return ana.tx.getBranch<float>  ("allHad_v23_dR"); } );
+    hists_allHad.add2DHistogram("genV12_dR", 60,   0,    5, "genV31_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_v12_dR");}, [&]() { return ana.tx.getBranch<float>  ("allHad_v31_dR"); } );
+    hists_allHad.add2DHistogram("genV31_dR", 60,   0,    5, "genV23_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_v31_dR");}, [&]() { return ana.tx.getBranch<float>  ("allHad_v23_dR"); } );  
+    hists_allHad.add2DHistogram("genV12_dPhi", 60,   0,    4, "genV23_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v12_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_v23_dPhi"); } );
+    hists_allHad.add2DHistogram("genV12_dPhi", 60,   0,    4, "genV31_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v12_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_v31_dPhi"); } );
+    hists_allHad.add2DHistogram("genV31_dPhi", 60,   0,    4, "genV23_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v31_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_v23_dPhi"); } );  
+    
+    hists_allHad.add2DHistogram("genV12_dR", 60,   0,    5, "FatJet12_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_v12_dR");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dR"); } );
+    hists_allHad.add2DHistogram("genV12_dPhi", 60,   0,  4, "FatJet12_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v12_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dPhi"); } );
+    hists_allHad.add2DHistogram("genV12_dEta", 60,   0,  4, "FatJet12_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v12_dEta");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dEta"); } );
+    
+    hists_allHad.add2DHistogram("genV23_dR", 60,   0,    5, "FatJet23_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_v23_dR");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj23_dR"); } );
+    hists_allHad.add2DHistogram("genV23_dPhi", 60,   0,  4, "FatJet23_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v23_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj23_dPhi"); } );
+    hists_allHad.add2DHistogram("genV23_dEta", 60,   0,  4, "FatJet23_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v23_dEta");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj23_dEta"); } );
+    
+    hists_allHad.add2DHistogram("genV31_dR", 60,   0,    5, "FatJet31_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_v31_dR");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj31_dR"); } );
+    hists_allHad.add2DHistogram("genV31_dPhi", 60,   0,  4, "FatJet31_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v31_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj31_dPhi"); } );
+    hists_allHad.add2DHistogram("genV31_dEta", 60,   0,  4, "FatJet31_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v31_dEta");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj31_dEta"); } );
+    
+    hists_allHad.addHistogram("genV12_dPhi"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_v12_dPhi"); } );
+    hists_allHad.addHistogram("genV12_dPhi_zoom"   ,  60,   2,    4, [&]() { return      ana.tx.getBranch<float>("allHad_v12_dPhi"); } );
+    hists_allHad.addHistogram("genV12_dEta"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_v12_dEta"); } );
+    hists_allHad.addHistogram("genV12_dR"     ,  60,   0,    5, [&]() { return      ana.tx.getBranch<float>("allHad_v12_dR"); } );
+    hists_allHad.addHistogram("genV23_dPhi"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_v23_dPhi"); } );
+    hists_allHad.addHistogram("genV23_dPhi_zoom"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_v23_dPhi"); } );
+    hists_allHad.addHistogram("genV23_dEta"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_v23_dEta"); } );
+    hists_allHad.addHistogram("genV23_dR"     ,  60,   0,    5, [&]() { return      ana.tx.getBranch<float>("allHad_v23_dR"); } );
+    hists_allHad.addHistogram("genV31_dPhi"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_v31_dPhi"); } );
+    hists_allHad.addHistogram("genV31_dPhi_zoom"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_v31_dPhi"); } );
+    hists_allHad.addHistogram("genV31_dEta"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_v31_dEta"); } );
+    hists_allHad.addHistogram("genV31_dR"     ,  60,   0,    5, [&]() { return      ana.tx.getBranch<float>("allHad_v31_dR"); } );
+  */
+  
+  
+   
+    ana.cutflow.bookCutflows(); 
+    
+    ana.cutflow.bookHistogramsForCut(hists_allHad, "allHad_fixedHT");
+    ana.cutflow.bookHistogramsForCutAndBelow(hists_allHad, "allHad_2fj_mSD_sideband");
+    ana.cutflow.bookHistogramsForCutAndBelow(hists_allHad, "allHad_2fj_1med1tight");
+    ana.cutflow.bookHistogramsForCutAndBelow(hists_allHad, "allHad_2fj_tight");
+    ana.cutflow.bookHistogramsForCutAndBelow(hists_allHad, "allHad_2fj_ABCD");
+    ana.cutflow.bookHistogramsForCutAndBelow(hists_allHad, "allHad_3fj_tight");
+    
+
+}
+
+void Begin_1L_VVVTree()
+{
     //vector branches
     ana.tx.createBranch<vector<float>>  ("allHad_FatJet_tau1");
     ana.tx.createBranch<vector<float>>  ("allHad_FatJet_tau2");
@@ -46,7 +913,7 @@ void Begin_allHad()
     
     
     // Single var branches
-    ana.tx.createBranch<float>  ("allHad_MET");
+    ana.tx.createBranch<float>  ("allHad_mindPhi_MetFJ");
     ana.tx.createBranch<float>  ("allHad_genHT");
     ana.tx.createBranch<float>  ("allHad_mVVV");
     ana.tx.createBranch<float>  ("allHad_HT");
@@ -63,6 +930,8 @@ void Begin_allHad()
     ana.tx.createBranch<float>  ("allHad_fj_ptVVV_reco");
     ana.tx.createBranch<float>  ("allHad_fj_mVVV_reco_nomet");
     ana.tx.createBranch<float>  ("allHad_fj_ptVVV_reco_nomet");
+    ana.tx.createBranch<float>  ("allHad_fj_mVVV_reco_nomet_SD");
+    ana.tx.createBranch<float>  ("allHad_fj_ptVVV_reco_nomet_SD");
     
     ana.tx.createBranch<float>  ("allHad_fj12_dPhi");
     ana.tx.createBranch<float>  ("allHad_fj12_dEta");
@@ -109,172 +978,56 @@ void Begin_allHad()
     ana.tx.createBranch<int>  ("allHad_nb_loose");
     ana.tx.createBranch<int>  ("allHad_nb_medium");
     ana.tx.createBranch<int>  ("allHad_nb_tight");
+    ana.tx.createBranch<int>  ("allHad_NFatJet_loose");
+    ana.tx.createBranch<int>  ("allHad_NFatJet_medium");
+    ana.tx.createBranch<int>  ("allHad_NFatJet_tight");
+    
 
-    // Define selections
-    // CommonCut will contain selections that should be common to all categories, starting from this cut, add cuts for this category of the analysis.
-    // Create histograms used in this category.
-    // Please follow the convention of h_<category>_<varname> structure.
-    // N.B. Using nbins of size 180 or 360 can provide flexibility as it can be rebinned easily, as 180, 360 are highly composite numbers.
-    
-    // Super basic selection for now -- 0 leptons and some jets
-   
-     
-    const int eft_reweighting_idx = ana.eft_reweighting_idx;
-    std::cout << "eft index " << eft_reweighting_idx << std::endl;
-    
-     
+    //at this point we've already skimmed
     ana.cutflow.getCut("CommonCut");
-    ana.cutflow.addCutToLastActiveCut("allHad", [&]() { 
 
-        if( ana.tx.getBranchLazy<vector<int>>("Common_lep_pdgid").size() > 0) return false; 
-        if( (ana.tx.getBranchLazy<vector<float>>("allHad_Jet_pt").size() + ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_pt").size()) < 1) return false; 
-             
+    const int eft_reweighting_idx = ana.eft_reweighting_idx;
+    std::cout << "eft index " << eft_reweighting_idx;
+    ana.cutflow.addCutToLastActiveCut("oneL_EFT", [&]() {
         return true;
-        
-        }, [&, eft_reweighting_idx]() { return  eft_reweighting_idx < 0 ? ana.tx.getBranchLazy<float>("Common_genWeight") :ana.tx.getBranchLazy<float>("Common_genWeight") * ana.tx.getBranchLazy<vector<float>>("Common_LHEWeight_mg_reweighting")[eft_reweighting_idx]; } );
+        }, [&, eft_reweighting_idx]() { return  eft_reweighting_idx < 0 ? 1.0 : ana.tx.getBranchLazy<float>("Common_genWeight") * ana.tx.getBranchLazy<vector<float>>("Common_LHEReweightingWeight")[eft_reweighting_idx]; } );
     
-/*    ana.cutflow.getCut("allHad");
-    ana.cutflow.addCutToLastActiveCut("allHad_scouting", [&](){
-        if (ana.tx.getBranchLazy<float>("allHad_HT") < 1100 && ana.tx.getBranchLazy<float>("allHad_HT") > 600)  return true;
+
+    //1 lep, orthogonal to qilong's SR
+    ana.cutflow.addCutToLastActiveCut("oneL_ptLep_l70", [&]() {
+        if (ana.tx.getBranchLazy<vector<LorentzVector>>("Common_lep_p4").size() == 0) return false;
+        if (ana.tx.getBranchLazy<vector<LorentzVector>>("Common_lep_p4")[0].Pt() < 70) return true;
         return false;
-    }, [&]() { return 1; } );
-  */  
-    
-    
-    ana.cutflow.getCut("allHad");
-    ana.cutflow.addCutToLastActiveCut("allHad_ORTrigger", [&]() {
-        if( ! (ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFJet400_TrimMass30") || ana.tx.getBranchLazy<bool>("Common_HLT_PFHT1050") || ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFJet500") || ana.tx.getBranchLazy<bool>("Common_HLT_AK8PFJet400_TrimMass30"))) return false;
-        if (ana.tx.getBranchLazy<float>("allHad_HT") < 1100) return false;
+        }, [&]() { return 1.0; } );
+
+    //building qilong's SR
+    ana.cutflow.addCutToLastActiveCut("oneL_QL_SR", [&]() {
+        if (ana.tx.getBranchLazy<int>("allHad_nb_medium") != 0 ) return false;
+        if (ana.tx.getBranchLazy<LorentzVector>("Common_met_p4").Pt() < 60) return false;
+        if ( getMT() < 150) return false;
+
         return true;
-    }, [&]() { return 1; } );
+        }, [&]() { return 1.0; } );
     
-    
-    ana.cutflow.getCut("allHad_ORTrigger");
-    ana.cutflow.addCutToLastActiveCut("allHad_CRb_2fj", [&]() {
-        if(ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_pt").size() == 2) return true;
-        if (ana.tx.getBranchLazy<int>("allHad_nb_medium") < 1 ) return false;
-        //if(ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_pt").size() == 2 && ana.tx.getBranchLazy<vector<int>>("Common_fatjet_idxs").size() == 2) return true;
+    ana.cutflow.addCutToLastActiveCut("oneL_1fj", [&]() {
+        if (ana.tx.getBranchLazy<vector<LorentzVector>>("Common_fatjet_p4").size() == 1) return true;
         return false;
-    }, [&]() { return 1; } );
+        }, [&]() { return 1.0; } );
     
-    ana.cutflow.getCut("allHad_ORTrigger");
-    ana.cutflow.addCutToLastActiveCut("allHad_CRb_SF_2fj", [&]() {
-        if(ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_pt").size() == 2) return true;
-        if (ana.tx.getBranchLazy<int>("allHad_nb_medium") < 1 ) return false;
-        //if(ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_pt").size() == 2 && ana.tx.getBranchLazy<vector<int>>("Common_fatjet_idxs").size() == 2) return true;
+    ana.cutflow.addCutToLastActiveCut("oneL_1fj_tight", [&]() {
+        if (ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[0] == 3 ) return true;
         return false;
-    }, [&]() { return ana.tx.getBranchLazy<float>("allHad_FatJet_SF"); } );
-     
-    
-     
-    ana.cutflow.getCut("allHad_ORTrigger");
-    ana.cutflow.addCutToLastActiveCut("allHad_ORTrigger_2fj", [&]() {
-        if(ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_pt").size() == 2) return true;
-        if (ana.tx.getBranchLazy<int>("allHad_nb_medium") > 0) return false;
-        //if(ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_pt").size() == 2 && ana.tx.getBranchLazy<vector<int>>("Common_fatjet_idxs").size() == 2) return true;
-        return false;
-    }, [&]() { return 1; } );
-    
-    ana.cutflow.getCut("allHad_ORTrigger");
-    ana.cutflow.addCutToLastActiveCut("allHad_ORTrigger_3fj", [&]() {
-        if(ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_pt").size() == 3) return true;
-        if (ana.tx.getBranchLazy<int>("allHad_nb_medium") > 0) return false;
-        return false;
-    }, [&]() { return 1; } );
-    
-    ana.cutflow.getCut("allHad_ORTrigger");
-    ana.cutflow.addCutToLastActiveCut("allHad_CRb_3fj", [&]() {
-        if(ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_pt").size() == 3) return true;
-        if (ana.tx.getBranchLazy<int>("allHad_nb_medium") < 1 ) return false;
-        //if(ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_pt").size() == 2 && ana.tx.getBranchLazy<vector<int>>("Common_fatjet_idxs").size() == 2) return true;
-        return false;
-    }, [&]() { return 1; } );
-    
-    ana.cutflow.getCut("allHad_ORTrigger");
-    ana.cutflow.addCutToLastActiveCut("allHad_CRb_SF_3fj", [&]() {
-        if(ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_pt").size() == 3) return true;
-        if (ana.tx.getBranchLazy<int>("allHad_nb_medium") < 1 ) return false;
-        //if(ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_pt").size() == 2 && ana.tx.getBranchLazy<vector<int>>("Common_fatjet_idxs").size() == 2) return true;
-        return false;
-    }, [&]() { return ana.tx.getBranchLazy<float>("allHad_FatJet_SF"); } );
-    
-    /*
-    //SR 1 -- 2fj, low mVVV, low pTVVV
-    ana.cutflow.getCut("allHad_ORTrigger_2fj");
-    ana.cutflow.addCutToLastActiveCut("allHad_SR1", [&]() {
-        if(ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco") < 2500 && ana.tx.getBranchLazy<float>("allHad_fj_ptVVV_reco") < 800) return true;
-        return false;
-    }, [&]() { return 1;} );
-    
-    //SR 2 -- 2fj, high mVVV, low pTVVV
-    ana.cutflow.getCut("allHad_ORTrigger_2fj");
-    ana.cutflow.addCutToLastActiveCut("allHad_SR2", [&]() {
-        if(ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco") > 2500 && ana.tx.getBranchLazy<float>("allHad_fj_ptVVV_reco") < 800) return true;
-        return false;
-    }, [&]() { return 1;} );
-    
-    //SR 3 -- 2fj, low mVVV, high pTVVV
-    ana.cutflow.getCut("allHad_ORTrigger_2fj");
-    ana.cutflow.addCutToLastActiveCut("allHad_SR3", [&]() {
-        if(ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco") < 2500 && ana.tx.getBranchLazy<float>("allHad_fj_ptVVV_reco") > 800) return true;
-        return false;
-    }, [&]() { return 1;});
-    
-    //SR 4 -- 2fj, high mVVV, high pTVVV
-    ana.cutflow.getCut("allHad_ORTrigger_2fj");
-    ana.cutflow.addCutToLastActiveCut("allHad_SR4", [&]() {
-        if(ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco") > 2500 && ana.tx.getBranchLazy<float>("allHad_fj_ptVVV_reco") > 800) return true;
-        return false;
-    }, [&]() { return 1;});
-    
-    
-    //SR 5 -- 3fj, low mVVV, low pTVVV
-    ana.cutflow.getCut("allHad_ORTrigger_3fj");
-    ana.cutflow.addCutToLastActiveCut("allHad_SR5", [&]() {
-        if(ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco") < 2500 && ana.tx.getBranchLazy<float>("allHad_fj_ptVVV_reco") < 800) return true;
-        return false;
-    }, [&]() { return 1;});
-    
-    //SR 6 -- 3fj, high mVVV, low pTVVV
-    ana.cutflow.getCut("allHad_ORTrigger_3fj");
-    ana.cutflow.addCutToLastActiveCut("allHad_SR6", [&]() {
-        if(ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco") > 2500 && ana.tx.getBranchLazy<float>("allHad_fj_ptVVV_reco") < 800) return true;
-        return false;
-    }, [&]() { return 1;});
-    
-    //SR 7 -- 3fj, low mVVV, high pTVVV
-    ana.cutflow.getCut("allHad_ORTrigger_3fj");
-    ana.cutflow.addCutToLastActiveCut("allHad_SR7", [&]() {
-        if(ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco") < 2500 && ana.tx.getBranchLazy<float>("allHad_fj_ptVVV_reco") > 800) return true;
-        return false;
-    }, [&]() { return 1;});
-    
-    //SR 8 -- 3fj, high mVVV, high pTVVV
-    ana.cutflow.getCut("allHad_ORTrigger_3fj");
-    ana.cutflow.addCutToLastActiveCut("allHad_SR8", [&]() {
-        if(ana.tx.getBranchLazy<float>("allHad_fj_mVVV_reco") > 2500 && ana.tx.getBranchLazy<float>("allHad_fj_ptVVV_reco") > 800) return true;
-        return false;
-    }, [&]() { return 1;});
-    */
+        }, [&]() { return 1.0; } );
 
+    ana.cutflow.addCutToLastActiveCut("oneL_2fj_tight", [&]() {
+        if (ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[1] == 3 ) return true;
+        return false;
+        }, [&]() { return 1.0; } );
 
-
+   
     
 
 
-    /* 
-    ana.cutflow.getCut("allHad");
-    ana.cutflow.addCutToLastActiveCut("SM",[&](){ return 1;}, [&]() {return ana.tx.getBranchLazy<vector<float>>("Common_LHEWeight_mg_reweighting")[0]; } );
-    
-    ana.cutflow.getCut("allHad");
-    ana.cutflow.addCutToLastActiveCut("EFT_FT0_10",[&](){ return 1;}, [&]() {return ana.tx.getBranchLazy<vector<float>>("Common_LHEWeight_mg_reweighting")[6]; } );
-    
-    ana.cutflow.getCut("allHad");
-    ana.cutflow.addCutToLastActiveCut("EFT_FT0_m10",[&](){ return 1;}, [&]() {return ana.tx.getBranchLazy<vector<float>>("Common_LHEWeight_mg_reweighting")[1]; } );
-    
-    ana.cutflow.getCut("allHad");
-    ana.cutflow.addCutToLastActiveCut("EFT_FT0_m5",[&](){ return 1;}, [&]() {return ana.tx.getBranchLazy<vector<float>>("Common_LHEWeight_mg_reweighting")[2]; } );
-    */
     RooUtil::Histograms hists_allHad;
 
     //single value histograms
@@ -283,92 +1036,39 @@ void Begin_allHad()
     hists_allHad.addHistogram("NGenFatJets"       ,  10,   0,   10, [&]() { return      ana.tx.getBranchLazy<vector<LorentzVector>>("Common_genFatJet_p4").size()   ; } );
     hists_allHad.addHistogram("NFatJets"         ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_pt").size() ; } );
     hists_allHad.addHistogram("NW"               ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<int>("Common_n_W") ; } );
-    //hists_allHad.addHistogram("gen_vvvdecay_n"               ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<vector<int>>("Common_gen_vvvdecay_idx").size() ; } );
+
     hists_allHad.addHistogram("n_b_loose"          ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<int>("allHad_nb_loose") ; } );
     hists_allHad.addHistogram("n_b_medium"          ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<int>("allHad_nb_medium") ; } );
-    hists_allHad.addHistogram("MET"              ,  40,   0,    1000, [&]() { return    ana.tx.getBranch<float>  ("allHad_MET"); } );
-    ///hists_allHad.addHistogram("mVVV"               ,  60,   0,    5000, [&]() { return    ana.tx.getBranch<float>  ("allHad_mVVV"); } );
+    hists_allHad.addHistogram("n_b_tight"          ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<int>("allHad_nb_tight") ; } );
+
+    hists_allHad.addHistogram("nFatJet_loose"          ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<int>("allHad_NFatJet_loose") ; } );
+    hists_allHad.addHistogram("nFatJet_medium"          ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<int>("allHad_NFatJet_medium") ; } );
+    hists_allHad.addHistogram("nFatJet_tight"          ,  10,   0,    10, [&]() { return      ana.tx.getBranchLazy<int>("allHad_NFatJet_tight") ; } );  
+
+    hists_allHad.addHistogram("MET"              ,  40,   0,    800, [&]() { return    ana.tx.getBranch<LorentzVector>  ("Common_met_p4").Pt(); } );
+
+    hists_allHad.addHistogram("MET_phi"              ,  40,   -4,    4, [&]() { return    ana.tx.getBranch<LorentzVector>  ("Common_met_p4").Phi(); } );
+    hists_allHad.addHistogram("METFJ_dPhi_min"       ,  40,   0,    4, [&]() { return    ana.tx.getBranch<float>  ("allHad_mindPhi_MetFJ"); } );
     hists_allHad.addHistogram("genHT"            ,  40,   0,    5000, [&]() { return    ana.tx.getBranch<float>  ("allHad_genHT"); } );
-    hists_allHad.addHistogram("HT"               ,  40,   0,    5000, [&]() { return    ana.tx.getBranch<float>  ("allHad_HT"); } );
-    hists_allHad.addHistogram("ST"               ,  40,   0,    5000, [&]() { return    ana.tx.getBranch<float>  ("allHad_ST"); } );
-    hists_allHad.addHistogram("mVVV_reco"               ,  60,   0,    5000, [&]() { return    ana.tx.getBranch<float>  ("allHad_mVVV_reco"); } );
-    hists_allHad.addHistogram("ptVVV_reco"               ,  60,   0,    5000, [&]() { return    ana.tx.getBranch<float>  ("allHad_ptVVV_reco"); } );
-    hists_allHad.addHistogram("mVVV_reco_nomet"               ,  60,   0,    5000, [&]() { return    ana.tx.getBranch<float>  ("allHad_mVVV_reco_nomet"); } );
-    hists_allHad.addHistogram("ptVVV_reco_nomet"               ,  60,   0,    5000, [&]() { return    ana.tx.getBranch<float>  ("allHad_ptVVV_reco_nomet"); } );
+    hists_allHad.addHistogram("HT"               ,  40,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_HT"); } );
+    hists_allHad.addHistogram("ST"               ,  40,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_ST"); } );
+    hists_allHad.addHistogram("mVVV_reco"               ,  60,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_mVVV_reco"); } );
+    hists_allHad.addHistogram("ptVVV_reco"               ,  60,   0,    800, [&]() { return    ana.tx.getBranch<float>  ("allHad_ptVVV_reco"); } );
+    hists_allHad.addHistogram("mVVV_reco_nomet"               ,  60,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_mVVV_reco_nomet"); } );
+    hists_allHad.addHistogram("ptVVV_reco_nomet"               ,  60,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_ptVVV_reco_nomet"); } );
     
-    hists_allHad.addHistogram("HT_fj"               ,  40,   0,    5000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_HT"); } );
-    hists_allHad.addHistogram("ST_fj"               ,  40,   0,    5000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_ST"); } );
-    hists_allHad.addHistogram("mVVV_reco_fj"               ,  60,   0,    5000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_mVVV_reco"); } );
-    hists_allHad.addHistogram("ptVVV_reco_fj"               ,  60,   0,    5000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco"); } );
-    hists_allHad.addHistogram("mVVV_reco_nomet_fj"               ,  60,   0,    5000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_mVVV_reco_nomet"); } );
-    hists_allHad.addHistogram("ptVVV_reco_nomet_fj"               ,  60,   0,    5000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco_nomet"); } );
-    
-    //hists_allHad.addHistogram("gen_vvv_pt0"       ,  20,   0,    2000,  [&]() { return (ana.tx.getBranch<vector<float>>("allHad_gen_vvv_pt").size() > 0) ?     ana.tx.getBranch<vector<float>>  ("allHad_gen_vvv_pt")[0] : -999; } );
-    //hists_allHad.addHistogram("gen_vvv_eta0"       ,  20,  0,    3,  [&]() { return   (ana.tx.getBranch<vector<float>>("allHad_gen_vvv_eta").size() > 0) ?   ana.tx.getBranch<vector<float>>  ("allHad_gen_vvv_eta")[0] : -999; } );
-    
-    hists_allHad.add2DHistogram("genHT", 60,   0,    3000, "HT", 40,   0,    3000, [&]() { return ana.tx.getBranch<float>  ("allHad_genHT");}, [&]() { return ana.tx.getBranch<float>  ("allHad_HT"); } );
-    hists_allHad.add2DHistogram("Njets", 6,   0,    6, "NFatjets", 6,   0,    6, [&]() { return ana.tx.getBranchLazy<vector<float>>("allHad_Jet_pt").size();}, [&]() { return ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_pt").size(); } );
-
-    // compare to MET 
-    hists_allHad.add2DHistogram("mVVV", 60,   0,    3000,      "MET", 40,   0,    2000, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV");}, [&]() { return ana.tx.getBranch<float>  ("allHad_MET"); } );
-    hists_allHad.add2DHistogram("HT", 60,   0,    5000,        "MET", 40,   0,    2000, [&]() { return ana.tx.getBranch<float>  ("allHad_HT");}, [&]() { return ana.tx.getBranch<float>  ("allHad_MET"); } );
-    hists_allHad.add2DHistogram("mVVV_reco", 60,   0,    5000, "MET", 40,   0,    2000, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_MET"); } );
-    hists_allHad.add2DHistogram("mVVV", 60,   0,    5000,      "ST", 60,   0,    5000, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV");}, [&]() { return ana.tx.getBranch<float>  ("allHad_ST"); } );
-    hists_allHad.add2DHistogram("mVVV_reco", 60,   0,    5000, "ST", 60,   0,    5000, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_ST"); } );
-    
-    //event vars with all jets
-    hists_allHad.add2DHistogram("mVVV", 60,   0,    5000,       "HT", 60,   0,    5000, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV");}, [&]() { return ana.tx.getBranch<float>  ("allHad_HT"); } );
-    hists_allHad.add2DHistogram("mVVV_reco", 60,   0,    5000,  "HT", 60,   0,    5000, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_HT"); } );
-    hists_allHad.add2DHistogram("ptVVV_reco", 60,   0,    5000, "HT", 60,   0,    5000, [&]() { return ana.tx.getBranch<float>  ("allHad_ptVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_HT"); } );
-    hists_allHad.add2DHistogram("mVVV", 60,   0,    5000,       "mVVV_reco", 60,   0,    5000, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV");}, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV_reco"); } );
-    hists_allHad.add2DHistogram("mVVV_reco", 60,   0,    5000, "ptVVV_reco", 60,   0,    5000, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_ptVVV_reco"); } );
-    
-    //event vars with fatjets
-    hists_allHad.add2DHistogram("mVVV_reco_fj", 60,   0,    5000, "ptVVV_reco_fj", 60,   0,    5000, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco"); } );
-    hists_allHad.add2DHistogram("mVVV_reco_fj", 60,   0,    5000,     "HT_fj", 60,   0,    5000, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_HT"); } );
-    hists_allHad.add2DHistogram("ptVVV_reco_fj", 60,   0,    5000,    "HT_fj", 60,   0,    5000, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_HT"); } );
-    hists_allHad.add2DHistogram("ptVVV_reco_fj", 60,   0,    5000,    "jet_pt_0", 60,   0,    1000, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco");}, [&]() { return ana.tx.getBranch<vector<float>>  ("allHad_Jet_pt")[0]; } );
-    hists_allHad.add2DHistogram("ptVVV_reco_fj", 60,   0,    5000,    "jet_pt_1", 60,   0,    1000, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco");}, [&]() { return ana.tx.getBranch<vector<float>>  ("allHad_Jet_pt")[1]; } );
-    hists_allHad.add2DHistogram("ptVVV_reco_fj", 60,   0,    5000,    "jet_pt_2", 60,   0,    1000, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco");}, [&]() { return ana.tx.getBranch<vector<float>>  ("allHad_Jet_pt")[2]; } );
-
-
-    //angular stuff
-    hists_allHad.add2DHistogram("FatJet12_dPhi", 60,   0,    4, "FatJet12_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dEta"); } );
-    hists_allHad.add2DHistogram("FatJet23_dPhi", 60,   0,    4, "FatJet23_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj23_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj23_dEta"); } );
-    hists_allHad.add2DHistogram("FatJet31_dPhi", 60,   0,    4, "FatJet31_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj31_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj31_dEta"); } );
-    hists_allHad.add2DHistogram("FatJet12_dR", 60,   0,    5, "FatJet23_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dR");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj23_dR"); } );
-    hists_allHad.add2DHistogram("FatJet12_dR", 60,   0,    5, "FatJet31_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dR");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj31_dR"); } );
-    hists_allHad.add2DHistogram("FatJet31_dR", 60,   0,    5, "FatJet23_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_fj31_dR");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj23_dR"); } );  
-    hists_allHad.add2DHistogram("FatJet12_dPhi", 60,   0,    4, "FatJet23_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj23_dPhi"); } );
-    hists_allHad.add2DHistogram("FatJet12_dPhi", 60,   0,    4, "FatJet31_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj31_dPhi"); } );
-    hists_allHad.add2DHistogram("FatJet31_dPhi", 60,   0,    4, "FatJet23_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj31_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj23_dPhi"); } );  
-    
-    
-    hists_allHad.add2DHistogram("ptVVV_reco_fj", 60,   0,    3000, "FatJet12_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dPhi"); } );
-    hists_allHad.add2DHistogram("ptVVV_reco_fj", 60,   0,    3000, "FatJet12_dPhi_zoom", 60,   2,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dPhi"); } );
-    hists_allHad.add2DHistogram("ptVVV_reco_fj", 60,   0,    3000, "FatJet12_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dEta"); } );   
-    hists_allHad.add2DHistogram("ptVVV_reco_fj", 60,   0,    3000, "FatJet12_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dR"); } );
-    hists_allHad.add2DHistogram("ptVVV_reco", 60,   0,    3000, "FatJet12_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_ptVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dPhi"); } );
-    hists_allHad.add2DHistogram("ptVVV_reco", 60,   0,    3000, "FatJet12_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_ptVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dEta"); } );   
-    hists_allHad.add2DHistogram("ptVVV_reco", 60,   0,    3000, "FatJet12_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_ptVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dR"); } );
-    hists_allHad.add2DHistogram("mVVV_reco_fj", 60,   0,    5000, "FatJet12_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dPhi"); } );
-    hists_allHad.add2DHistogram("mVVV_reco_fj", 60,   0,    5000, "FatJet12_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dEta"); } );   
-    hists_allHad.add2DHistogram("mVVV_reco_fj", 60,   0,    5000, "FatJet12_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_fj_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dR"); } );
-    hists_allHad.add2DHistogram("mVVV_reco", 60,   0,    5000, "FatJet12_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dPhi"); } );
-    hists_allHad.add2DHistogram("mVVV_reco", 60,   0,    5000, "FatJet12_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dEta"); } );   
-    hists_allHad.add2DHistogram("mVVV_reco", 60,   0,    5000, "FatJet12_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_mVVV_reco");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dR"); } );
-
-    hists_allHad.add2DHistogram("fatjet_1_eta", 60,   -3,    3, "fatjet_2_eta", 60,   -3,    3, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 1) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_eta")[0] : -999;}, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 1) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_eta")[1] : -999; } );
-    hists_allHad.add2DHistogram("fatjet_1_phi", 60,   -4,    4, "fatjet_2_phi", 60,   -4,    4, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 1) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_phi")[0] : -999;}, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 1) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_phi")[1] : -999; } );
-
-    hists_allHad.add2DHistogram("fatjet_2_eta", 60,   -3,    3, "fatjet_3_eta", 60,   -3,    3, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 2) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_eta")[1] : -999;}, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 2) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_eta")[2] : -999; } );
-    hists_allHad.add2DHistogram("fatjet_3_eta", 60,   -3,    3, "fatjet_1_eta", 60,   -3,    3, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 2) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_eta")[2] : -999;}, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 2) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_eta")[1] : -999; } );
-    hists_allHad.add2DHistogram("fatjet_2_phi", 60,   -4,    4, "fatjet_3_phi", 60,   -4,    4, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 2) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_phi")[1] : -999;}, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 2) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_phi")[2] : -999; } );
-    hists_allHad.add2DHistogram("fatjet_3_phi", 60,   -4,    4, "fatjet_1_phi", 60,   -4,    4, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 2) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_phi")[2] : -999;}, [&]() { return (ana.tx.getBranch<vector<float>>("allHad_FatJet_pt").size() > 2) ? ana.tx.getBranch<vector<float>>  ("allHad_FatJet_phi")[1] : -999; } );
-
+    hists_allHad.addHistogram("HT_fj"               ,  40,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_HT"); } );
+    hists_allHad.addHistogram("ST_fj"               ,  40,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_ST"); } );
+    hists_allHad.addHistogram("mVVV_reco_fj"               ,  60,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_mVVV_reco"); } );
+    hists_allHad.addHistogram("ptVVV_reco_fj"               ,  60,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco"); } );
+    hists_allHad.addHistogram("mVVV_reco_nomet_fj"               ,  60,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_mVVV_reco_nomet"); } );
+    hists_allHad.addHistogram("ptVVV_reco_nomet_fj"               ,  60,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco_nomet"); } );
+    hists_allHad.addHistogram("mVVV_reco_nomet_fj_SD"               ,  60,   0,    4000, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_mVVV_reco_nomet_SD"); } );
+    hists_allHad.addHistogram("ptVVV_reco_nomet_fj_SD"               ,  60,   0,    800, [&]() { return    ana.tx.getBranch<float>  ("allHad_fj_ptVVV_reco_nomet_SD"); } );
+ 
 
     hists_allHad.addHistogram("FatJet12_dPhi"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_fj12_dPhi"); } );
-    hists_allHad.addHistogram("FatJet12_dPhi_zoom"   ,  60,   2,    4, [&]() { return      ana.tx.getBranch<float>("allHad_fj12_dPhi"); } );
+    hists_allHad.addHistogram("FatJet12_dPhi_zoom"   ,  60,   2.5,    3.2, [&]() { return      ana.tx.getBranch<float>("allHad_fj12_dPhi"); } );
     hists_allHad.addHistogram("FatJet12_dEta"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_fj12_dEta"); } );
     hists_allHad.addHistogram("FatJet12_dR"     ,  60,   0,    5, [&]() { return      ana.tx.getBranch<float>("allHad_fj12_dR"); } );
     hists_allHad.addHistogram("FatJet23_dPhi"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_fj23_dPhi"); } );
@@ -381,11 +1081,7 @@ void Begin_allHad()
     hists_allHad.addHistogram("FatJet31_dR"     ,  60,   0,    5, [&]() { return      ana.tx.getBranch<float>("allHad_fj31_dR"); } );
 
 
-    //small R jets
-    hists_allHad.add2DHistogram("jet12_mass", 60,   0,    1000, "jet12_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_j12_mass");}, [&]() { return ana.tx.getBranch<float>  ("allHad_j12_dR"); } );
-    hists_allHad.add2DHistogram("jet23_mass", 60,   0,    1000, "jet23_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_j23_mass");}, [&]() { return ana.tx.getBranch<float>  ("allHad_j23_dR"); } );
-    hists_allHad.add2DHistogram("jet31_mass", 60,   0,    1000, "jet31_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_j31_mass");}, [&]() { return ana.tx.getBranch<float>  ("allHad_j31_dR"); } );
-
+    
     hists_allHad.addHistogram("jet12_mass"          ,  60,   0,    500, [&]() { return  ana.tx.getBranch<float>("allHad_j12_mass") ; } );
     hists_allHad.addHistogram("jet23_mass"          ,  60,   0,    500, [&]() { return  ana.tx.getBranch<float>("allHad_j23_mass") ; } );
     hists_allHad.addHistogram("jet31_mass"          ,  60,   0,    500, [&]() { return  ana.tx.getBranch<float>("allHad_j31_mass") ; } );
@@ -398,27 +1094,12 @@ void Begin_allHad()
     hists_allHad.addHistogram("FatJet_eta_0"          ,  20,   -3,    3, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_eta").size() > 0) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_eta")[0] : -999 ; } );
     hists_allHad.addHistogram("FatJet_eta_1"          ,  20,   -3,    3, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_eta").size() > 1) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_eta")[1] : -999 ; } );
     hists_allHad.addHistogram("FatJet_eta_2"          ,  20,   -3,    3, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_eta").size() > 2) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_eta")[2] : -999 ; } );
-    
-    hists_allHad.addHistogram("FatJet_M_0"          ,  40,   0,    1000, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_M").size() > 0) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_M")[0] : -999 ; } );
-    hists_allHad.addHistogram("FatJet_M_1"          ,  40,   0,    1000, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_M").size() > 1) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_M")[1] : -999 ; } );
-    hists_allHad.addHistogram("FatJet_M_2"          ,  40,   0,    1000, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_M").size() > 2) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_M")[2] : -999 ; } );
+
     
     hists_allHad.addHistogram("FatJet_tau21_0"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau21").size() > 0) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau21")[0] : -999 ; } );
     hists_allHad.addHistogram("FatJet_tau21_1"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau21").size() > 1) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau21")[1] : -999 ; } );
     hists_allHad.addHistogram("FatJet_tau21_2"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau21").size() > 2) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau21")[2] : -999 ; } );
-    
-    hists_allHad.addHistogram("FatJet_tau1_0"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau1").size() > 0) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau1")[0] : -999 ; } );
-    hists_allHad.addHistogram("FatJet_tau1_1"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau1").size() > 1) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau1")[1] : -999 ; } );
-    hists_allHad.addHistogram("FatJet_tau1_2"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau1").size() > 2) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau1")[2] : -999 ; } );
-    
-    hists_allHad.addHistogram("FatJet_tau2_0"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau2").size() > 0) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau2")[0] : -999 ; } );
-    hists_allHad.addHistogram("FatJet_tau2_1"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau2").size() > 1) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau2")[1] : -999 ; } );
-    hists_allHad.addHistogram("FatJet_tau2_2"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau2").size() > 2) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau2")[2] : -999 ; } );
-    
-    hists_allHad.addHistogram("FatJet_tau3_0"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau3").size() > 0) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau3")[0] : -999 ; } );
-    hists_allHad.addHistogram("FatJet_tau3_1"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau3").size() > 1) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau3")[1] : -999 ; } );
-    hists_allHad.addHistogram("FatJet_tau3_2"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau3").size() > 2) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau3")[2] : -999 ; } );
-    
+
     
     hists_allHad.addHistogram("FatJet_tau32_0"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau32").size() > 0) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau32")[0] : -999 ; } );
     hists_allHad.addHistogram("FatJet_tau32_1"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_tau32").size() > 1) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_tau32")[1] : -999 ; } );
@@ -436,9 +1117,9 @@ void Begin_allHad()
     hists_allHad.addHistogram("FatJet_Ttag_1"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_Ttag").size() > 1) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_Ttag")[1] : -999 ; } );
     hists_allHad.addHistogram("FatJet_Ttag_2"          ,  30,   0,    1, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_Ttag").size() > 2) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_Ttag")[2] : -999 ; } );
     
-    hists_allHad.addHistogram("FatJet_msoftdrop_0"          ,  40,   50,    150, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_msoftdrop").size() > 0) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_msoftdrop")[0] : -999 ; } );
-    hists_allHad.addHistogram("FatJet_msoftdrop_1"          ,  40,   50,    150, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_msoftdrop").size() > 1) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_msoftdrop")[1] : -999 ; } );
-    hists_allHad.addHistogram("FatJet_msoftdrop_2"          ,  40,   50,    150, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_msoftdrop").size() > 2) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_msoftdrop")[2] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_msoftdrop_0"          ,  40,   0,    200, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_msoftdrop").size() > 0) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_msoftdrop")[0] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_msoftdrop_1"          ,  40,   0,    200, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_msoftdrop").size() > 1) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_msoftdrop")[1] : -999 ; } );
+    hists_allHad.addHistogram("FatJet_msoftdrop_2"          ,  40,   0,    200, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_FatJet_msoftdrop").size() > 2) ? ana.tx.getBranch<vector<float>>("allHad_FatJet_msoftdrop")[2] : -999 ; } );
     
     hists_allHad.addHistogram("Jet_pt_0"          ,  40,   0,    2000, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_Jet_pt").size() > 0) ? ana.tx.getBranch<vector<float>>("allHad_Jet_pt")[0] : -999 ; } );
     hists_allHad.addHistogram("Jet_pt_1"          ,  40,   0,    2000, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_Jet_pt").size() > 1) ? ana.tx.getBranch<vector<float>>("allHad_Jet_pt")[1] : -999 ; } );
@@ -450,62 +1131,85 @@ void Begin_allHad()
     hists_allHad.addHistogram("Jet_eta_2"          ,  20,   -3,    3, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_Jet_eta").size() > 2) ? ana.tx.getBranch<vector<float>>("allHad_Jet_eta")[2] : -999 ; } );
     hists_allHad.addHistogram("Jet_eta_3"          ,  20,   -3,    3, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_Jet_eta").size() > 3) ? ana.tx.getBranch<vector<float>>("allHad_Jet_eta")[3] : -999; } );
     
-    hists_allHad.addHistogram("genV_status_0"          ,  10,   0,    10, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_genV_status").size() > 0) ? ana.tx.getBranch<vector<float>>("allHad_genV_status")[0] : -999 ; } );
-    hists_allHad.addHistogram("genV_status_1"          ,  10,   0,    10, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_genV_status").size() > 1) ? ana.tx.getBranch<vector<float>>("allHad_genV_status")[1] : -999 ; } );
-    hists_allHad.addHistogram("genV_status_2"          ,  10,   0,    10, [&]() { return      (ana.tx.getBranch<vector<float>>("allHad_genV_status").size() > 2) ? ana.tx.getBranch<vector<float>>("allHad_genV_status")[2] : -999 ; } );
     
-    
-    hists_allHad.addHistogram("NGenLeptons"       ,  10,   0,   10, [&]() { return      ana.tx.getBranchLazy<int>("allHad_nGenLeps")   ; } );
-    hists_allHad.addHistogram("NGenQuarks"       ,  10,   0,   10, [&]() { return      ana.tx.getBranchLazy<int>("allHad_nGenQuarks")   ; } );
-    hists_allHad.addHistogram("NGenV"       ,  10,   0,   10, [&]() { return      ana.tx.getBranchLazy<int>("allHad_nGenV")   ; } );
-    hists_allHad.addHistogram("FatJet_0_NMatchedQuarks"       ,  10,   0,   10, [&]() { return  (ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_nMatchedQuarks").size() > 0 ) ?    ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_nMatchedQuarks")[0] : -999  ; } );
-    hists_allHad.addHistogram("FatJet_1_NMatchedQuarks"       ,  10,   0,   10, [&]() { return  (ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_nMatchedQuarks").size() > 1 ) ?    ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_nMatchedQuarks")[1] : -999  ; } );
-    hists_allHad.addHistogram("FatJet_2_NMatchedQuarks"       ,  10,   0,   10, [&]() { return  (ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_nMatchedQuarks").size() > 2 ) ?    ana.tx.getBranchLazy<vector<float>>("allHad_FatJet_nMatchedQuarks")[2] : -999  ; } );
-    hists_allHad.addHistogram("NGenJets"       ,  10,   0,   10, [&]() { return      ana.tx.getBranchLazy<vector<LorentzVector>>("Common_genJet_p4").size()   ; } );
-    hists_allHad.addVecHistogram("gen_vvvdecay_pdgid"       ,  20,   0,    20,  [&]() { return      ana.tx.getBranch<vector<float>>  ("allHad_gen_vvvdecay_pdgid"); } );
-    
-    hists_allHad.add2DHistogram("genV12_dPhi", 60,   0,    4, "genV12_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v12_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_v12_dEta"); } );
-    hists_allHad.add2DHistogram("genV23_dPhi", 60,   0,    4, "genV23_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v23_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_v23_dEta"); } );
-    hists_allHad.add2DHistogram("genV31_dPhi", 60,   0,    4, "genV31_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v31_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_v31_dEta"); } );
-    hists_allHad.add2DHistogram("genV12_dR", 60,   0,    5, "genV23_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_v12_dR");}, [&]() { return ana.tx.getBranch<float>  ("allHad_v23_dR"); } );
-    hists_allHad.add2DHistogram("genV12_dR", 60,   0,    5, "genV31_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_v12_dR");}, [&]() { return ana.tx.getBranch<float>  ("allHad_v31_dR"); } );
-    hists_allHad.add2DHistogram("genV31_dR", 60,   0,    5, "genV23_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_v31_dR");}, [&]() { return ana.tx.getBranch<float>  ("allHad_v23_dR"); } );  
-    hists_allHad.add2DHistogram("genV12_dPhi", 60,   0,    4, "genV23_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v12_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_v23_dPhi"); } );
-    hists_allHad.add2DHistogram("genV12_dPhi", 60,   0,    4, "genV31_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v12_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_v31_dPhi"); } );
-    hists_allHad.add2DHistogram("genV31_dPhi", 60,   0,    4, "genV23_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v31_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_v23_dPhi"); } );  
-    
-    hists_allHad.add2DHistogram("genV12_dR", 60,   0,    5, "FatJet12_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_v12_dR");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dR"); } );
-    hists_allHad.add2DHistogram("genV12_dPhi", 60,   0,  4, "FatJet12_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v12_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dPhi"); } );
-    hists_allHad.add2DHistogram("genV12_dEta", 60,   0,  4, "FatJet12_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v12_dEta");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj12_dEta"); } );
-    
-    hists_allHad.add2DHistogram("genV23_dR", 60,   0,    5, "FatJet23_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_v23_dR");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj23_dR"); } );
-    hists_allHad.add2DHistogram("genV23_dPhi", 60,   0,  4, "FatJet23_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v23_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj23_dPhi"); } );
-    hists_allHad.add2DHistogram("genV23_dEta", 60,   0,  4, "FatJet23_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v23_dEta");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj23_dEta"); } );
-    
-    hists_allHad.add2DHistogram("genV31_dR", 60,   0,    5, "FatJet31_dR", 60,   0,    5, [&]() { return ana.tx.getBranch<float>  ("allHad_v31_dR");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj31_dR"); } );
-    hists_allHad.add2DHistogram("genV31_dPhi", 60,   0,  4, "FatJet31_dPhi", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v31_dPhi");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj31_dPhi"); } );
-    hists_allHad.add2DHistogram("genV31_dEta", 60,   0,  4, "FatJet31_dEta", 60,   0,    4, [&]() { return ana.tx.getBranch<float>  ("allHad_v31_dEta");}, [&]() { return ana.tx.getBranch<float>  ("allHad_fj31_dEta"); } );
-    
-    hists_allHad.addHistogram("genV12_dPhi"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_v12_dPhi"); } );
-    hists_allHad.addHistogram("genV12_dPhi_zoom"   ,  60,   2,    4, [&]() { return      ana.tx.getBranch<float>("allHad_v12_dPhi"); } );
-    hists_allHad.addHistogram("genV12_dEta"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_v12_dEta"); } );
-    hists_allHad.addHistogram("genV12_dR"     ,  60,   0,    5, [&]() { return      ana.tx.getBranch<float>("allHad_v12_dR"); } );
-    hists_allHad.addHistogram("genV23_dPhi"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_v23_dPhi"); } );
-    hists_allHad.addHistogram("genV23_dPhi_zoom"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_v23_dPhi"); } );
-    hists_allHad.addHistogram("genV23_dEta"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_v23_dEta"); } );
-    hists_allHad.addHistogram("genV23_dR"     ,  60,   0,    5, [&]() { return      ana.tx.getBranch<float>("allHad_v23_dR"); } );
-    hists_allHad.addHistogram("genV31_dPhi"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_v31_dPhi"); } );
-    hists_allHad.addHistogram("genV31_dPhi_zoom"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_v31_dPhi"); } );
-    hists_allHad.addHistogram("genV31_dEta"   ,  60,   0,    4, [&]() { return      ana.tx.getBranch<float>("allHad_v31_dEta"); } );
-    hists_allHad.addHistogram("genV31_dR"     ,  60,   0,    5, [&]() { return      ana.tx.getBranch<float>("allHad_v31_dR"); } );
-  
-  
   
    
     ana.cutflow.bookCutflows(); 
     
-    ana.cutflow.bookHistogramsForCut(hists_allHad, "allHad_ORTrigger_2fj");
-    ana.cutflow.bookHistogramsForCut(hists_allHad, "allHad_ORTrigger_3fj");
-    ana.cutflow.bookHistogramsForCut(hists_allHad, "allHad_CRb_2fj");
-    ana.cutflow.bookHistogramsForCut(hists_allHad, "allHad_CRb_3fj");
+    ana.cutflow.bookHistogramsForCutAndBelow(hists_allHad, "oneL_ptLep_l70");
+}
+
+
+
+
+
+
+bool is_baseline_jet(unsigned int i){
+    if( ana.tx.getBranchLazy<vector<int>>("Common_jet_id")[i] != 6 ) return false;
+    
+    if ( ana.tx.getBranchLazy<vector<int>>("Common_jet_overlapfatjet")[i]) return false;
+
+    return true;
+}
+
+bool is_baseline_fatjet(unsigned int i, bool firstPTcut, bool SDcut){
+    if( ana.tx.getBranchLazy<vector<LorentzVector>>("Common_fatjet_p4")[i].Pt() < 200 ) return false;
+    if( abs(ana.tx.getBranchLazy<vector<LorentzVector>>("Common_fatjet_p4")[i].Eta()) > 2.4 ) return false;
+
+    if (ana.tx.getBranchLazy<vector<int>>("Common_fatjet_id")[i] != 6) return false;
+    
+    //if( ana.tx.getBranchLazy<vector<int>>("Common_fatjet_WP")[i] < 1) return false;
+
+    //first jet pT > 500 GeV
+    if(firstPTcut){
+        if( i == 0 && ana.tx.getBranchLazy<vector<LorentzVector>>("Common_fatjet_p4")[i].Pt() < 500 ) return false;
+    }
+
+    if(SDcut){
+        if( !(ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[i] >= 65. && ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[i] <= 105. ) ) return false;
+    }
+    else{
+        if( ! (ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[i] >= 40. && ana.tx.getBranchLazy<vector<float>>("Common_fatjet_msoftdrop")[i] <= 150. ) ) return false;
+
+    }
+
+    return true;
+}
+
+
+float getMT(){
+    LorentzVector MET = ana.tx.getBranchLazy<LorentzVector>("Common_met_p4");
+    LorentzVector lep = ana.tx.getBranchLazy<vector<LorentzVector>>("Common_lep_p4")[0];
+
+    float MT = TMath::Sqrt(2*lep.Pt()*MET.Pt()*(1.0-TMath::Cos(lep.Phi() - MET.Phi())));
+
+    //std::cout <<" MT "  << MT << std::endl;;
+    return MT;
+}
+
+float get_weight(){
+    //deal with this later
+    if( ana.is_EFT_sample) return 1.0;
+
+    TFile* inputfile = TFile::Open(ana.input_file_list_tstring);
+    TH1F* h_nevents = (TH1F*) inputfile->Get("Wgt__h_nevents"); // Should be "Wgt" to be accurate but the tree does not save event weight (i.e. the sign)
+    float n_total_events = h_nevents->GetBinContent(1);
+    
+    //fix this later
+    float lumi = 59.74;
+
+    float xsecbr = -999;
+    if (ana.input_file_list_tstring.Contains("/QCD_HT700to1000.root"         )) xsecbr = 6831.;
+    if (ana.input_file_list_tstring.Contains("/QCD_HT1000to1500.root"         )) xsecbr = 1207.;
+    if (ana.input_file_list_tstring.Contains("/QCD_HT1500to2000.root"         )) xsecbr = 119.9;
+    if (ana.input_file_list_tstring.Contains("/QCD_HT2000toInf.root"          )) xsecbr = 119.9;
+
+    std::cout << " GOT " << ana.input_file_list_tstring << " with " << xsecbr << std::endl;
+    if( xsecbr > 0 ){
+        return xsecbr*lumi/n_total_events*1000;
+    }
+    //for samples i am not dealing with yet
+    else return 1.0;
+
+
 }

--- a/src/Begin_allHad.h
+++ b/src/Begin_allHad.h
@@ -4,5 +4,12 @@
 #include "AnalysisConfig.h"
 
 void Begin_allHad();
-
+void Begin_allHad_NanoAOD();
+void Begin_1L_NanoAOD();
+void Begin_allHad_VVVTree();
+void Begin_1L_VVVTree();
+bool is_baseline_jet(unsigned int i);
+bool is_baseline_fatjet(unsigned int i, bool firstPTcut, bool SDcut);
+float getMT();
+float get_weight();
 #endif

--- a/src/Process.cc
+++ b/src/Process.cc
@@ -46,6 +46,7 @@ void Process()
             case AnalysisConfig::kOS2jet: break;
             case AnalysisConfig::kSS2jet: PostProcess_SS2jet(); break;
             case AnalysisConfig::k1Lep4jet: break;
+            case AnalysisConfig::kallHad: PostProcess_allHad(); break;
             case AnalysisConfig::k1Lep2fatJets: break;
         }
     }

--- a/src/Process_Common.cc
+++ b/src/Process_Common.cc
@@ -70,6 +70,17 @@ void Process_Common_NanoAOD()
     try { ana.tx.setBranch<bool>("Common_HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL"    , nt.HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL());    } catch (std::runtime_error) { ana.tx.setBranch<bool>("Common_HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL"    , 0); } 
     try { ana.tx.setBranch<bool>("Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ"  , nt.HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ());  } catch (std::runtime_error) { ana.tx.setBranch<bool>("Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ"  , 0); } // Lowest unprescaled
     try { ana.tx.setBranch<bool>("Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL"     , nt.HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL());     } catch (std::runtime_error) { ana.tx.setBranch<bool>("Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL"     , 0); } 
+    try { ana.tx.setBranch<bool>("Common_HLT_PFHT1050"                                       , nt.HLT_PFHT1050());                                       } catch (std::runtime_error) { std::cout << "HLT_PFHT1050 not found"<< std::endl; ana.tx.setBranch<bool>("HLT_PFHT1050"     , 0); } 
+    try { ana.tx.setBranch<bool>("Common_HLT_AK8PFJet500"                                     , nt.HLT_AK8PFJet500());                                   } catch (std::runtime_error) { std::cout << "HLT_AK8PFJet500 not found"<< std::endl; ana.tx.setBranch<bool>("HLT_AK8PFJet500"     , 0); } 
+    try { ana.tx.setBranch<bool>("Common_HLT_AK8PFJet380_TrimMass30"     , nt.HLT_AK8PFJet380_TrimMass30());     } catch (std::runtime_error) { std::cout << "HLT_AK8PFJet380 not found"<< std::endl; ana.tx.setBranch<bool>("HLT_AK8PFJet380_TrimMass30"     , 0); } 
+    try { ana.tx.setBranch<bool>("Common_HLT_AK8PFJet360_TrimMass30"     , nt.HLT_AK8PFJet360_TrimMass30());     } catch (std::runtime_error) { std::cout << "HLT_AK8PFJet360 not found"<< std::endl; ana.tx.setBranch<bool>("HLT_AK8PFJet360_TrimMass30"     , 0); } 
+    try { ana.tx.setBranch<bool>("Common_HLT_AK8PFJet400_TrimMass30"     , nt.HLT_AK8PFJet400_TrimMass30());     } catch (std::runtime_error) { std::cout << "HLT_AK8PFJet400 not found"<< std::endl; ana.tx.setBranch<bool>("HLT_AK8PFJet400_TrimMass30"     , 0); } 
+    try { ana.tx.setBranch<bool>("Common_HLT_AK8PFJet420_TrimMass30"     , nt.HLT_AK8PFJet420_TrimMass30());     } catch (std::runtime_error) { std::cout << "HLT_AK8PFJet420 not found"<< std::endl; ana.tx.setBranch<bool>("HLT_AK8PFJet420_TrimMass30"     , 0); } 
+    try { ana.tx.setBranch<bool>("Common_HLT_AK8PFHT750_TrimMass50"     , nt.HLT_AK8PFHT750_TrimMass50());     } catch (std::runtime_error) { std::cout << "HLT_AK8PFHT750 not found"<< std::endl; ana.tx.setBranch<bool>("HLT_AK8PFHT750_TrimMass50"     , 0); } 
+    try { ana.tx.setBranch<bool>("Common_HLT_AK8PFHT800_TrimMass50"     , nt.HLT_AK8PFHT800_TrimMass50());     } catch (std::runtime_error) { std::cout << "HLT_AK8PFHT800 not found"<< std::endl; ana.tx.setBranch<bool>("HLT_AK8PFHT800_TrimMass50"     , 0); } 
+    try { ana.tx.setBranch<bool>("Common_HLT_AK8PFHT850_TrimMass50"     , nt.HLT_AK8PFHT850_TrimMass50());     } catch (std::runtime_error) { std::cout << "HLT_AK8PFHT7850 not found"<< std::endl; ana.tx.setBranch<bool>("HLT_AK8PFHT850_TrimMass50"     , 0); } 
+    try { ana.tx.setBranch<bool>("Common_HLT_AK8PFHT900_TrimMass50"     , nt.HLT_AK8PFHT900_TrimMass50());     } catch (std::runtime_error) { std::cout << "HLT_AK8PFHT900 not found"<< std::endl; ana.tx.setBranch<bool>("HLT_AK8PFHT900_TrimMass50"     , 0); } 
+
 
     bool is_pd_ee = ana.looper.getCurrentFileName().Contains("DoubleEG") or ana.looper.getCurrentFileName().Contains("EGamma");
     bool is_pd_em = ana.looper.getCurrentFileName().Contains("MuonEG");
@@ -756,40 +767,44 @@ void Process_Common_NanoAOD()
     float fjSFvlc(1.), fjSFvlu(1.), fjSFvld(1.), fjSFlc(1.), fjSFlu(1.), fjSFld(1.), fjSFmc(1.), fjSFmu(1.), fjSFmd(1.), fjSFtc(1.), fjSFtu(1.), fjSFtd(1.);
     for (unsigned int ifatjet = 0; ifatjet < nt.FatJet_p4().size(); ++ifatjet)
     {
-        float fjWPvloose = 0.274; //https://twiki.cern.ch/twiki/bin/view/CMS/DeepAK8Tagging2018WPsSFs
-        float fjWPloose  = 0.506;
-        float fjWPmedium = 0.731;
-        float fjWPtight  = 0.828;
+        //TODO update with final WPs and for other years
+        //currently from https://indico.cern.ch/event/1103765/contributions/4647556/attachments/2364610/4037250/ParticleNet_2018_ULNanoV9_JMAR_14Dec2021_PK.pdf
+        //Lesya updated March 22 2022
+        float fjWPloose  = 1;
+        float fjWPmedium = 1;
+        float fjWPtight  = 1;
+        
+        float fjWPloose_MD  = 1;
+        float fjWPmedium_MD = 1;
+        float fjWPtight_MD  = 1;
         if (nt.year() == 2017)
         {
-            fjWPvloose = 0.258;
-            fjWPloose  = 0.506;
-            fjWPmedium = 0.739;
-            fjWPtight  = 0.838;
         }
         if (nt.year() == 2018)
         {
-            fjWPvloose = 0.245;
-            fjWPloose  = 0.479;
-            fjWPmedium = 0.704;
-            fjWPtight  = 0.806;
+            fjWPloose  = 0.70;
+            fjWPmedium = 0.94;
+            fjWPtight  = 0.98;
+            fjWPloose_MD  = 0.59;
+            fjWPmedium_MD = 0.82;
+            fjWPtight_MD  = 0.90;
         }
 
         LorentzVector fatjet_p4;
-	float fatjet_msoftdrop;
+        float fatjet_msoftdrop;
         if (ana.is_postprocessed)
         {
             //if postprocessed NanoAOD, set pt to pt_nom, mass to mass_nom msoftdrop to msoftdrop_nom
             fatjet_p4=LorentzVector(nt.FatJet_pt_nom()[ifatjet],nt.FatJet_eta()[ifatjet],nt.FatJet_phi()[ifatjet],nt.FatJet_mass_nom()[ifatjet]);
             fatjet_msoftdrop = nt.FatJet_msoftdrop_nom()[ifatjet];
         }
-	else
-	{
+        else
+        {
             fatjet_p4 = nt.FatJet_p4()[ifatjet];
             fatjet_msoftdrop = nt.FatJet_msoftdrop()[ifatjet];
 
         }
-           
+
         // TODO: What is POG recommendation? do we use nt.FatJet_jetId()?
         // Figure this out
         if (not (fatjet_p4.pt() > 180.))
@@ -827,6 +842,9 @@ void Process_Common_NanoAOD()
 
         if (is_overlapping_with_a_lepton)
             continue;
+        
+        //computed with instructions from NanoAOD reference "For W vs QCD tagging, use (Xcc+Xqq)/(Xcc+Xqq+QCD)"
+        float W_MD = ( nt.FatJet_particleNetMD_Xcc()[ifatjet] + nt.FatJet_particleNetMD_Xqq()[ifatjet]) / (nt.FatJet_particleNetMD_Xcc()[ifatjet] + nt.FatJet_particleNetMD_Xqq()[ifatjet] + nt.FatJet_particleNetMD_QCD()[ifatjet]);
 
         // For now, accept anything that reaches this point
         ana.tx.pushbackToBranch<int>("Common_fatjet_idxs", ifatjet);
@@ -843,6 +861,12 @@ void Process_Common_NanoAOD()
         ana.tx.pushbackToBranch<float>("Common_fatjet_particleNet_W", nt.FatJet_particleNet_WvsQCD()[ifatjet]);
         ana.tx.pushbackToBranch<float>("Common_fatjet_particleNet_Z", nt.FatJet_particleNet_ZvsQCD()[ifatjet]);
         ana.tx.pushbackToBranch<float>("Common_fatjet_particleNet_T", nt.FatJet_particleNet_TvsQCD()[ifatjet]);
+        ana.tx.pushbackToBranch<float>("Common_fatjet_particleNet_QCD", nt.FatJet_particleNet_QCD()[ifatjet]);
+        ana.tx.pushbackToBranch<float>("Common_fatjet_particleNetMD_QCD", nt.FatJet_particleNetMD_QCD()[ifatjet]);
+        ana.tx.pushbackToBranch<float>("Common_fatjet_particleNetMD_Xqq", nt.FatJet_particleNetMD_Xqq()[ifatjet]);
+        ana.tx.pushbackToBranch<float>("Common_fatjet_particleNetMD_Xbb", nt.FatJet_particleNetMD_Xbb()[ifatjet]);
+        ana.tx.pushbackToBranch<float>("Common_fatjet_particleNetMD_Xcc", nt.FatJet_particleNetMD_Xcc()[ifatjet]);
+        ana.tx.pushbackToBranch<float>("Common_fatjet_particleNetMD_W", W_MD);
         ana.tx.pushbackToBranch<float>("Common_fatjet_tau3",  nt.FatJet_tau3()[ifatjet]);
         ana.tx.pushbackToBranch<float>("Common_fatjet_tau2",  nt.FatJet_tau2()[ifatjet]);
         ana.tx.pushbackToBranch<float>("Common_fatjet_tau1",  nt.FatJet_tau1()[ifatjet]);
@@ -885,19 +909,27 @@ void Process_Common_NanoAOD()
 
         float WPtemp = 0;
         int WPid = -999;
+        int WPid_MD = -999;
 
-        if (nt.FatJet_deepTagMD_WvsQCD()[ifatjet] > fjWPvloose) WPid = 0;
-        if (nt.FatJet_deepTagMD_WvsQCD()[ifatjet] > fjWPloose) WPid = 1;
-        if (nt.FatJet_deepTagMD_WvsQCD()[ifatjet] > fjWPmedium) WPid = 2;
-        if (nt.FatJet_deepTagMD_WvsQCD()[ifatjet] > fjWPtight) WPid = 3;
+
+        if (nt.FatJet_particleNet_WvsQCD()[ifatjet] > fjWPloose) WPid = 1;
+        if (nt.FatJet_particleNet_WvsQCD()[ifatjet] > fjWPmedium) WPid = 2;
+        if (nt.FatJet_particleNet_WvsQCD()[ifatjet] > fjWPtight) WPid = 3;
+
+        if (W_MD > fjWPloose_MD) WPid_MD = 1; 
+        if (W_MD > fjWPmedium_MD) WPid_MD = 2; 
+        if (W_MD > fjWPtight_MD) WPid_MD = 3; 
+        
         if (fatjet_msoftdrop >= 65. and fatjet_msoftdrop <= 105. and fatjet_p4.pt() > 200.)
         {
             ana.tx.pushbackToBranch<int>("Common_fatjet_WP", WPid);
+            ana.tx.pushbackToBranch<int>("Common_fatjet_WP_MD", WPid_MD);
             ana.tx.pushbackToBranch<int>("Common_fatjet_WP_antimasscut", -999);
         }
         else
         {
             ana.tx.pushbackToBranch<int>("Common_fatjet_WP", -999);
+            ana.tx.pushbackToBranch<int>("Common_fatjet_WP_MD", -999);
             ana.tx.pushbackToBranch<int>("Common_fatjet_WP_antimasscut", WPid); // store W DNN cut even off mass peak
             WPid = -999.;                                                       // I reset WPid to not store the fatjet SF for offmass peak
         }
@@ -1435,6 +1467,16 @@ void Process_Common_VVVTree()
     ana.tx.setBranch<bool>                 ("Common_HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL", vvv.Common_HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL());
     ana.tx.setBranch<bool>                 ("Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ", vvv.Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ()); // Lowest unprescaled
     ana.tx.setBranch<bool>                 ("Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL", vvv.Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL());
+    ana.tx.setBranch<bool>                 ("Common_HLT_PFHT1050"                                  , vvv.Common_HLT_PFHT1050());                                      
+    ana.tx.setBranch<bool>                 ("Common_HLT_AK8PFJet500"                               , vvv.Common_HLT_AK8PFJet500());                                   
+    ana.tx.setBranch<bool>                 ("Common_HLT_AK8PFJet380_TrimMass30"                    , vvv.Common_HLT_AK8PFJet380_TrimMass30());     
+    ana.tx.setBranch<bool>                 ("Common_HLT_AK8PFJet360_TrimMass30"                    , vvv.Common_HLT_AK8PFJet360_TrimMass30());    
+    ana.tx.setBranch<bool>                 ("Common_HLT_AK8PFJet400_TrimMass30"                    , vvv.Common_HLT_AK8PFJet400_TrimMass30());     
+    ana.tx.setBranch<bool>                 ("Common_HLT_AK8PFJet420_TrimMass30"                    , vvv.Common_HLT_AK8PFJet420_TrimMass30());     
+    ana.tx.setBranch<bool>                 ("Common_HLT_AK8PFHT750_TrimMass50"                     , vvv.Common_HLT_AK8PFHT750_TrimMass50());      
+    ana.tx.setBranch<bool>                 ("Common_HLT_AK8PFHT800_TrimMass50"                     , vvv.Common_HLT_AK8PFHT800_TrimMass50());     
+    ana.tx.setBranch<bool>                 ("Common_HLT_AK8PFHT850_TrimMass50"                     , vvv.Common_HLT_AK8PFHT850_TrimMass50());     
+    ana.tx.setBranch<bool>                 ("Common_HLT_AK8PFHT900_TrimMass50"                    , vvv.Common_HLT_AK8PFHT900_TrimMass50()); 
     // Summary triggers
     ana.tx.setBranch<bool>                 ("Common_HLT_DoubleEl", vvv.Common_HLT_DoubleEl());
     ana.tx.setBranch<bool>                 ("Common_HLT_MuEG", vvv.Common_HLT_MuEG());
@@ -1473,6 +1515,7 @@ void Process_Common_VVVTree()
     // Jet variables
     ana.tx.setBranch<vector<LorentzVector>>("Common_jet_p4", vvv.Common_jet_p4());            // Pt sorted selected jet p4s
     ana.tx.setBranch<vector<int>>          ("Common_jet_idxs", vvv.Common_jet_idxs());          // Pt sorted selected jet idxs (To access rest of the jet variables in NanoAOD)
+    ana.tx.setBranch<vector<int>>          ("Common_jet_id", vvv.Common_jet_id());          // Pt sorted selected jet idxs (To access rest of the jet variables in NanoAOD)
     ana.tx.setBranch<vector<bool>>         ("Common_jet_passBloose", vvv.Common_jet_passBloose());    // Pt sorted selected jet idxs (To access rest of the jet variables in NanoAOD)
     ana.tx.setBranch<vector<bool>>         ("Common_jet_passBmedium", vvv.Common_jet_passBmedium());   // Pt sorted selected jet idxs (To access rest of the jet variables in NanoAOD)
     ana.tx.setBranch<vector<bool>>         ("Common_jet_passBtight", vvv.Common_jet_passBtight());    // Pt sorted selected jet idxs (To access rest of the jet variables in NanoAOD)
@@ -1490,6 +1533,7 @@ void Process_Common_VVVTree()
     // Fat jet variables
     ana.tx.setBranch<vector<LorentzVector>>("Common_fatjet_p4", vvv.Common_fatjet_p4());            // Pt sorted selected fatjet p4s
     ana.tx.setBranch<vector<int>>          ("Common_fatjet_idxs", vvv.Common_fatjet_idxs());          // Pt sorted selected fatjet idxs (To access rest of the fatjet variables in NanoAOD)
+    ana.tx.setBranch<vector<int>>          ("Common_fatjet_id", vvv.Common_fatjet_id());          // Pt sorted selected fatjet idxs (To access rest of the fatjet variables in NanoAOD)
     ana.tx.setBranch<vector<float>>        ("Common_fatjet_msoftdrop", vvv.Common_fatjet_msoftdrop());     // Pt sorted selected fatjet msoftdrop (To access rest of the fatjet variables in NanoAOD)
     ana.tx.setBranch<vector<float>>        ("Common_fatjet_deepMD_W", vvv.Common_fatjet_deepMD_W());      // Pt sorted selected fatjet FatJet_deepTagMD_WvsQCD (To access rest of the fatjet variables in NanoAOD)
     ana.tx.setBranch<vector<float>>        ("Common_fatjet_deep_W", vvv.Common_fatjet_deep_W());        // Pt sorted selected fatjet FatJet_deepTag_WvsQCD (To access rest of the fatjet variables in NanoAOD)
@@ -1498,6 +1542,15 @@ void Process_Common_VVVTree()
     ana.tx.setBranch<vector<float>>        ("Common_fatjet_deepMD_T", vvv.Common_fatjet_deepMD_T());      // Pt sorted selected fatjet FatJet_deepTagMD_TvsQCD (To access rest of the fatjet variables in NanoAOD)
     ana.tx.setBranch<vector<float>>        ("Common_fatjet_deep_T", vvv.Common_fatjet_deep_T());        // Pt sorted selected fatjet FatJet_deepTag_TvsQCD (To access rest of the fatjet variables in NanoAOD)
     ana.tx.setBranch<vector<float>>        ("Common_fatjet_deepMD_bb", vvv.Common_fatjet_deepMD_bb());     // Pt sorted selected fatjet FatJet_deepTagMD_bbvsLight (To access rest of the fatjet variables in NanoAOD)
+    ana.tx.setBranch<vector<float>>        ("Common_fatjet_particleNet_W", vvv.Common_fatjet_particleNet_W());        // Pt sorted selected fatjet FatJet_particleNetTag_WvsQCD (To access rest of the fatjet variables in NanoAOD)
+    ana.tx.setBranch<vector<float>>        ("Common_fatjet_particleNet_Z", vvv.Common_fatjet_particleNet_Z());        // Pt sorted selected fatjet FatJet_particleNetTag_WvsQCD (To access rest of the fatjet variables in NanoAOD)
+    ana.tx.setBranch<vector<float>>        ("Common_fatjet_particleNet_T", vvv.Common_fatjet_particleNet_T());        // Pt sorted selected fatjet FatJet_particleNetTag_WvsQCD (To access rest of the fatjet variables in NanoAOD)
+    ana.tx.setBranch<vector<float>>        ("Common_fatjet_particleNet_QCD", vvv.Common_fatjet_particleNet_QCD());        // Pt sorted selected fatjet FatJet_particleNetTag_WvsQCD (To access rest of the fatjet variables in NanoAOD)
+    ana.tx.setBranch<vector<float>>        ("Common_fatjet_particleNetMD_QCD", vvv.Common_fatjet_particleNetMD_QCD());        // Pt sorted selected fatjet FatJet_particleNetTag_WvsQCD (To access rest of the fatjet variables in NanoAOD)
+    ana.tx.setBranch<vector<float>>        ("Common_fatjet_particleNetMD_W", vvv.Common_fatjet_particleNetMD_W());        // Pt sorted selected fatjet FatJet_particleNetTag_WvsW (To access rest of the fatjet variables in NanoAOD)
+    ana.tx.setBranch<vector<float>>        ("Common_fatjet_particleNetMD_Xqq", vvv.Common_fatjet_particleNetMD_Xqq());        // Pt sorted selected fatjet FatJet_particleNetTag_WvsXqq (To access rest of the fatjet variables in NanoAOD)
+    ana.tx.setBranch<vector<float>>        ("Common_fatjet_particleNetMD_Xcc", vvv.Common_fatjet_particleNetMD_Xcc());        // Pt sorted selected fatjet FatJet_particleNetTag_WvsXcc (To access rest of the fatjet variables in NanoAOD)
+    ana.tx.setBranch<vector<float>>        ("Common_fatjet_particleNetMD_Xbb", vvv.Common_fatjet_particleNetMD_Xbb());        // Pt sorted selected fatjet FatJet_particleNetTag_WvsXbb (To abbess rest of the fatjet variables in NanoAOD)
     ana.tx.setBranch<vector<float>>        ("Common_fatjet_tau3", vvv.Common_fatjet_tau3());          // Pt sorted selected fatjet FatJet_deepTagMD_bbvsLight (To access rest of the fatjet variables in NanoAOD)
     ana.tx.setBranch<vector<float>>        ("Common_fatjet_tau2", vvv.Common_fatjet_tau2());          // Pt sorted selected fatjet FatJet_deepTagMD_bbvsLight (To access rest of the fatjet variables in NanoAOD)
     ana.tx.setBranch<vector<float>>        ("Common_fatjet_tau1", vvv.Common_fatjet_tau1());          // Pt sorted selected fatjet FatJet_deepTagMD_bbvsLight (To access rest of the fatjet variables in NanoAOD)
@@ -1514,6 +1567,7 @@ void Process_Common_VVVTree()
     ana.tx.setBranch<vector<LorentzVector>>("Common_fatjet_subjet0_p4", vvv.Common_fatjet_subjet0_p4());    // Pt sorted selected fatjet p4s
     ana.tx.setBranch<vector<LorentzVector>>("Common_fatjet_subjet1_p4", vvv.Common_fatjet_subjet1_p4());    // Pt sorted selected fatjet p4s
     ana.tx.setBranch<vector<int>>          ("Common_fatjet_WP", vvv.Common_fatjet_WP());            // WP: 0: VLoose (5%), 1: Loose (2.5%), 2: Medium (1%), 3: Tight (0.5%)
+    ana.tx.setBranch<vector<int>>          ("Common_fatjet_WP_MD", vvv.Common_fatjet_WP_MD());            // WP: 0: VLoose (5%), 1: Loose (2.5%), 2: Medium (1%), 3: Tight (0.5%)
     ana.tx.setBranch<vector<int>>          ("Common_fatjet_WP_antimasscut", vvv.Common_fatjet_WP_antimasscut());// WP: 0: VLoose (5%), 1: Loose (2.5%), 2: Medium (1%), 3: Tight (0.5%)
     ana.tx.setBranch<vector<float>>        ("Common_fatjet_SFVLoose", vvv.Common_fatjet_SFVLoose());      // single fatjet SF
     ana.tx.setBranch<vector<float>>        ("Common_fatjet_SFLoose", vvv.Common_fatjet_SFLoose());       // single fatjet SF

--- a/src/Process_allHad.h
+++ b/src/Process_allHad.h
@@ -4,5 +4,9 @@
 #include "AnalysisConfig.h"
 
 void Process_allHad();
+void Process_allHad_NanoAOD();
+void Process_allHad_VVVTree();
+void PostProcess_allHad();
+
 
 #endif

--- a/src/Terminate.cc
+++ b/src/Terminate.cc
@@ -27,17 +27,6 @@ void Terminate()
         case AnalysisConfig::k1Lep2fatJets: Terminate_1Lep2fatjet(); break;
     }
 
-    // if we filter events in the VVVun
-    TFile* InputFile = TFile::Open(ana.input_file_list_tstring);
-    TH1D* nEventGenWeighted = (TH1D*)InputFile->Get("nEventsGenWeighted");
-    if ( nEventGenWeighted ){
-        ana.output_tfile->cd();
-        nEventGenWeighted->Write();
-    }
-    else {
-        cout << "nEventsGenWeighted not exist" << endl;
-    }
-    InputFile->Close();
 
     // Writing output file
     ana.cutflow.saveOutput();
@@ -51,6 +40,15 @@ void Terminate()
     {
         ana.output_tree->Fill(); // Fill an empty dummy event to pass rigorous sweep root. (So condor jobs don't delete it, because it's empty.)
         ana.output_tree->Write();
+    }
+    if(ana.run_VVVTree){
+        TFile* inputfile = TFile::Open(ana.input_file_list_tstring);
+        TH1F* h_nevents = (TH1F*) inputfile->Get("Wgt__h_nevents"); // Should be "Wgt" to be accurate but the tree does not save event weight (i.e. the sign)
+        TH1F* h_mg_reweight = (TH1F*) inputfile->Get("Root__h_Common_LHEWeight_mg_reweighting_times_genWeight");
+        ana.output_tfile->cd();
+
+        if(h_mg_reweight) h_mg_reweight->Write();
+        h_nevents->Write();
     }
 
     // The below can be sometimes crucial

--- a/src/Terminate.cc
+++ b/src/Terminate.cc
@@ -23,6 +23,7 @@ void Terminate()
         case AnalysisConfig::kOS2jet: Terminate_OS2jet(); break;
         case AnalysisConfig::kSS2jet: Terminate_SS2jet(); break;
         case AnalysisConfig::k1Lep4jet: Terminate_1Lep4jet(); break;
+        case AnalysisConfig::kallHad: Terminate_allHad(); break;
         case AnalysisConfig::k1Lep2fatJets: Terminate_1Lep2fatjet(); break;
     }
 

--- a/src/Terminate.h
+++ b/src/Terminate.h
@@ -11,6 +11,7 @@
 #include "Terminate_OS2jet.h"
 #include "Terminate_OS4jet.h"
 #include "Terminate_SS2jet.h"
+#include "Terminate_allHad.h"
 #include "Terminate_1Lep2fatjet.h"
 
 void Terminate();

--- a/src/Terminate_allHad.cc
+++ b/src/Terminate_allHad.cc
@@ -1,0 +1,15 @@
+#include "Terminate_allHad.h"
+
+void Terminate_allHad()
+{
+    //==============================================
+    // Terminate_allHad:
+    // This function gets called after the event looping.
+    // This is where one does stuff that needs to happen after the event looping for category allHad.
+    //==============================================
+
+    // To place eventlist writing or something that needs to happen post loop.
+    // TODO: implement event list writing
+
+
+}

--- a/src/Terminate_allHad.h
+++ b/src/Terminate_allHad.h
@@ -1,0 +1,8 @@
+#ifndef Terminate_allHad_h
+#define Terminate_allHad_h
+
+#include "AnalysisConfig.h"
+
+void Terminate_allHad();
+
+#endif

--- a/src/VVVTree.cc
+++ b/src/VVVTree.cc
@@ -6,6 +6,18 @@ void VVVTree::Init(TTree *tree) {
 /*                           Common_met_p4*/  Common_met_p4_branch = tree->GetBranch("Common_met_p4");
 /*                           Common_met_p4*/  if (Common_met_p4_branch) Common_met_p4_branch->SetAddress(&Common_met_p4_);
 //---------------------------------------------------------------------------------
+/*                     Common_met_p4_jesup*/  Common_met_p4_jesup_branch = tree->GetBranch("Common_met_p4_jesup");
+/*                     Common_met_p4_jesup*/  if (Common_met_p4_jesup_branch) Common_met_p4_jesup_branch->SetAddress(&Common_met_p4_jesup_);
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jesdn*/  Common_met_p4_jesdn_branch = tree->GetBranch("Common_met_p4_jesdn");
+/*                     Common_met_p4_jesdn*/  if (Common_met_p4_jesdn_branch) Common_met_p4_jesdn_branch->SetAddress(&Common_met_p4_jesdn_);
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jerup*/  Common_met_p4_jerup_branch = tree->GetBranch("Common_met_p4_jerup");
+/*                     Common_met_p4_jerup*/  if (Common_met_p4_jerup_branch) Common_met_p4_jerup_branch->SetAddress(&Common_met_p4_jerup_);
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jerdn*/  Common_met_p4_jerdn_branch = tree->GetBranch("Common_met_p4_jerdn");
+/*                     Common_met_p4_jerdn*/  if (Common_met_p4_jerdn_branch) Common_met_p4_jerdn_branch->SetAddress(&Common_met_p4_jerdn_);
+//---------------------------------------------------------------------------------
 /*                           Common_lep_p4*/  Common_lep_p4_branch = tree->GetBranch("Common_lep_p4");
 /*                           Common_lep_p4*/  if (Common_lep_p4_branch) Common_lep_p4_branch->SetAddress(&Common_lep_p4_);
 //---------------------------------------------------------------------------------
@@ -61,6 +73,36 @@ void VVVTree::Init(TTree *tree) {
 /*              Common_btagWeight_DeepCSVB*/  Common_btagWeight_DeepCSVB_branch = tree->GetBranch("Common_btagWeight_DeepCSVB");
 /*              Common_btagWeight_DeepCSVB*/  if (Common_btagWeight_DeepCSVB_branch) Common_btagWeight_DeepCSVB_branch->SetAddress(&Common_btagWeight_DeepCSVB_);
 //---------------------------------------------------------------------------------
+/*                              Common_wgt*/  Common_wgt_branch = tree->GetBranch("Common_wgt");
+/*                              Common_wgt*/  if (Common_wgt_branch) Common_wgt_branch->SetAddress(&Common_wgt_);
+//---------------------------------------------------------------------------------
+/*                   Common_event_puWeight*/  Common_event_puWeight_branch = tree->GetBranch("Common_event_puWeight");
+/*                   Common_event_puWeight*/  if (Common_event_puWeight_branch) Common_event_puWeight_branch->SetAddress(&Common_event_puWeight_);
+//---------------------------------------------------------------------------------
+/*                 Common_event_puWeightup*/  Common_event_puWeightup_branch = tree->GetBranch("Common_event_puWeightup");
+/*                 Common_event_puWeightup*/  if (Common_event_puWeightup_branch) Common_event_puWeightup_branch->SetAddress(&Common_event_puWeightup_);
+//---------------------------------------------------------------------------------
+/*                 Common_event_puWeightdn*/  Common_event_puWeightdn_branch = tree->GetBranch("Common_event_puWeightdn");
+/*                 Common_event_puWeightdn*/  if (Common_event_puWeightdn_branch) Common_event_puWeightdn_branch->SetAddress(&Common_event_puWeightdn_);
+//---------------------------------------------------------------------------------
+/*              Common_event_prefireWeight*/  Common_event_prefireWeight_branch = tree->GetBranch("Common_event_prefireWeight");
+/*              Common_event_prefireWeight*/  if (Common_event_prefireWeight_branch) Common_event_prefireWeight_branch->SetAddress(&Common_event_prefireWeight_);
+//---------------------------------------------------------------------------------
+/*            Common_event_prefireWeightup*/  Common_event_prefireWeightup_branch = tree->GetBranch("Common_event_prefireWeightup");
+/*            Common_event_prefireWeightup*/  if (Common_event_prefireWeightup_branch) Common_event_prefireWeightup_branch->SetAddress(&Common_event_prefireWeightup_);
+//---------------------------------------------------------------------------------
+/*            Common_event_prefireWeightdn*/  Common_event_prefireWeightdn_branch = tree->GetBranch("Common_event_prefireWeightdn");
+/*            Common_event_prefireWeightdn*/  if (Common_event_prefireWeightdn_branch) Common_event_prefireWeightdn_branch->SetAddress(&Common_event_prefireWeightdn_);
+//---------------------------------------------------------------------------------
+/*              Common_event_triggerWeight*/  Common_event_triggerWeight_branch = tree->GetBranch("Common_event_triggerWeight");
+/*              Common_event_triggerWeight*/  if (Common_event_triggerWeight_branch) Common_event_triggerWeight_branch->SetAddress(&Common_event_triggerWeight_);
+//---------------------------------------------------------------------------------
+/*            Common_event_triggerWeightup*/  Common_event_triggerWeightup_branch = tree->GetBranch("Common_event_triggerWeightup");
+/*            Common_event_triggerWeightup*/  if (Common_event_triggerWeightup_branch) Common_event_triggerWeightup_branch->SetAddress(&Common_event_triggerWeightup_);
+//---------------------------------------------------------------------------------
+/*            Common_event_triggerWeightdn*/  Common_event_triggerWeightdn_branch = tree->GetBranch("Common_event_triggerWeightdn");
+/*            Common_event_triggerWeightdn*/  if (Common_event_triggerWeightdn_branch) Common_event_triggerWeightdn_branch->SetAddress(&Common_event_triggerWeightdn_);
+//---------------------------------------------------------------------------------
 /*         Common_LHEWeight_mg_reweighting*/  Common_LHEWeight_mg_reweighting_branch = tree->GetBranch("Common_LHEWeight_mg_reweighting");
 /*         Common_LHEWeight_mg_reweighting*/  if (Common_LHEWeight_mg_reweighting_branch) Common_LHEWeight_mg_reweighting_branch->SetAddress(&Common_LHEWeight_mg_reweighting_);
 //---------------------------------------------------------------------------------
@@ -90,6 +132,36 @@ void VVVTree::Init(TTree *tree) {
 //---------------------------------------------------------------------------------
 /*Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL*/  Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_branch = tree->GetBranch("Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL");
 /*Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL*/  if (Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_branch) Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_branch->SetAddress(&Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_);
+//---------------------------------------------------------------------------------
+/*                     Common_HLT_PFHT1050*/  Common_HLT_PFHT1050_branch = tree->GetBranch("Common_HLT_PFHT1050");
+/*                     Common_HLT_PFHT1050*/  if (Common_HLT_PFHT1050_branch) Common_HLT_PFHT1050_branch->SetAddress(&Common_HLT_PFHT1050_);
+//---------------------------------------------------------------------------------
+/*                  Common_HLT_AK8PFJet500*/  Common_HLT_AK8PFJet500_branch = tree->GetBranch("Common_HLT_AK8PFJet500");
+/*                  Common_HLT_AK8PFJet500*/  if (Common_HLT_AK8PFJet500_branch) Common_HLT_AK8PFJet500_branch->SetAddress(&Common_HLT_AK8PFJet500_);
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet380_TrimMass30*/  Common_HLT_AK8PFJet380_TrimMass30_branch = tree->GetBranch("Common_HLT_AK8PFJet380_TrimMass30");
+/*       Common_HLT_AK8PFJet380_TrimMass30*/  if (Common_HLT_AK8PFJet380_TrimMass30_branch) Common_HLT_AK8PFJet380_TrimMass30_branch->SetAddress(&Common_HLT_AK8PFJet380_TrimMass30_);
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet360_TrimMass30*/  Common_HLT_AK8PFJet360_TrimMass30_branch = tree->GetBranch("Common_HLT_AK8PFJet360_TrimMass30");
+/*       Common_HLT_AK8PFJet360_TrimMass30*/  if (Common_HLT_AK8PFJet360_TrimMass30_branch) Common_HLT_AK8PFJet360_TrimMass30_branch->SetAddress(&Common_HLT_AK8PFJet360_TrimMass30_);
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet400_TrimMass30*/  Common_HLT_AK8PFJet400_TrimMass30_branch = tree->GetBranch("Common_HLT_AK8PFJet400_TrimMass30");
+/*       Common_HLT_AK8PFJet400_TrimMass30*/  if (Common_HLT_AK8PFJet400_TrimMass30_branch) Common_HLT_AK8PFJet400_TrimMass30_branch->SetAddress(&Common_HLT_AK8PFJet400_TrimMass30_);
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet420_TrimMass30*/  Common_HLT_AK8PFJet420_TrimMass30_branch = tree->GetBranch("Common_HLT_AK8PFJet420_TrimMass30");
+/*       Common_HLT_AK8PFJet420_TrimMass30*/  if (Common_HLT_AK8PFJet420_TrimMass30_branch) Common_HLT_AK8PFJet420_TrimMass30_branch->SetAddress(&Common_HLT_AK8PFJet420_TrimMass30_);
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT750_TrimMass50*/  Common_HLT_AK8PFHT750_TrimMass50_branch = tree->GetBranch("Common_HLT_AK8PFHT750_TrimMass50");
+/*        Common_HLT_AK8PFHT750_TrimMass50*/  if (Common_HLT_AK8PFHT750_TrimMass50_branch) Common_HLT_AK8PFHT750_TrimMass50_branch->SetAddress(&Common_HLT_AK8PFHT750_TrimMass50_);
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT800_TrimMass50*/  Common_HLT_AK8PFHT800_TrimMass50_branch = tree->GetBranch("Common_HLT_AK8PFHT800_TrimMass50");
+/*        Common_HLT_AK8PFHT800_TrimMass50*/  if (Common_HLT_AK8PFHT800_TrimMass50_branch) Common_HLT_AK8PFHT800_TrimMass50_branch->SetAddress(&Common_HLT_AK8PFHT800_TrimMass50_);
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT850_TrimMass50*/  Common_HLT_AK8PFHT850_TrimMass50_branch = tree->GetBranch("Common_HLT_AK8PFHT850_TrimMass50");
+/*        Common_HLT_AK8PFHT850_TrimMass50*/  if (Common_HLT_AK8PFHT850_TrimMass50_branch) Common_HLT_AK8PFHT850_TrimMass50_branch->SetAddress(&Common_HLT_AK8PFHT850_TrimMass50_);
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT900_TrimMass50*/  Common_HLT_AK8PFHT900_TrimMass50_branch = tree->GetBranch("Common_HLT_AK8PFHT900_TrimMass50");
+/*        Common_HLT_AK8PFHT900_TrimMass50*/  if (Common_HLT_AK8PFHT900_TrimMass50_branch) Common_HLT_AK8PFHT900_TrimMass50_branch->SetAddress(&Common_HLT_AK8PFHT900_TrimMass50_);
 //---------------------------------------------------------------------------------
 /*                     Common_HLT_DoubleEl*/  Common_HLT_DoubleEl_branch = tree->GetBranch("Common_HLT_DoubleEl");
 /*                     Common_HLT_DoubleEl*/  if (Common_HLT_DoubleEl_branch) Common_HLT_DoubleEl_branch->SetAddress(&Common_HLT_DoubleEl_);
@@ -129,6 +201,84 @@ void VVVTree::Init(TTree *tree) {
 //---------------------------------------------------------------------------------
 /*                  Common_event_lepSFmudn*/  Common_event_lepSFmudn_branch = tree->GetBranch("Common_event_lepSFmudn");
 /*                  Common_event_lepSFmudn*/  if (Common_event_lepSFmudn_branch) Common_event_lepSFmudn_branch->SetAddress(&Common_event_lepSFmudn_);
+//---------------------------------------------------------------------------------
+/*                 Common_event_lepSFTight*/  Common_event_lepSFTight_branch = tree->GetBranch("Common_event_lepSFTight");
+/*                 Common_event_lepSFTight*/  if (Common_event_lepSFTight_branch) Common_event_lepSFTight_branch->SetAddress(&Common_event_lepSFTight_);
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFelupTight*/  Common_event_lepSFelupTight_branch = tree->GetBranch("Common_event_lepSFelupTight");
+/*             Common_event_lepSFelupTight*/  if (Common_event_lepSFelupTight_branch) Common_event_lepSFelupTight_branch->SetAddress(&Common_event_lepSFelupTight_);
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFeldnTight*/  Common_event_lepSFeldnTight_branch = tree->GetBranch("Common_event_lepSFeldnTight");
+/*             Common_event_lepSFeldnTight*/  if (Common_event_lepSFeldnTight_branch) Common_event_lepSFeldnTight_branch->SetAddress(&Common_event_lepSFeldnTight_);
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFmuupTight*/  Common_event_lepSFmuupTight_branch = tree->GetBranch("Common_event_lepSFmuupTight");
+/*             Common_event_lepSFmuupTight*/  if (Common_event_lepSFmuupTight_branch) Common_event_lepSFmuupTight_branch->SetAddress(&Common_event_lepSFmuupTight_);
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFmudnTight*/  Common_event_lepSFmudnTight_branch = tree->GetBranch("Common_event_lepSFmudnTight");
+/*             Common_event_lepSFmudnTight*/  if (Common_event_lepSFmudnTight_branch) Common_event_lepSFmudnTight_branch->SetAddress(&Common_event_lepSFmudnTight_);
+//---------------------------------------------------------------------------------
+/*                Common_event_tightBtagSF*/  Common_event_tightBtagSF_branch = tree->GetBranch("Common_event_tightBtagSF");
+/*                Common_event_tightBtagSF*/  if (Common_event_tightBtagSF_branch) Common_event_tightBtagSF_branch->SetAddress(&Common_event_tightBtagSF_);
+//---------------------------------------------------------------------------------
+/*              Common_event_tightBtagSFup*/  Common_event_tightBtagSFup_branch = tree->GetBranch("Common_event_tightBtagSFup");
+/*              Common_event_tightBtagSFup*/  if (Common_event_tightBtagSFup_branch) Common_event_tightBtagSFup_branch->SetAddress(&Common_event_tightBtagSFup_);
+//---------------------------------------------------------------------------------
+/*              Common_event_tightBtagSFdn*/  Common_event_tightBtagSFdn_branch = tree->GetBranch("Common_event_tightBtagSFdn");
+/*              Common_event_tightBtagSFdn*/  if (Common_event_tightBtagSFdn_branch) Common_event_tightBtagSFdn_branch->SetAddress(&Common_event_tightBtagSFdn_);
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFHFup*/  Common_event_tightBtagSFHFup_branch = tree->GetBranch("Common_event_tightBtagSFHFup");
+/*            Common_event_tightBtagSFHFup*/  if (Common_event_tightBtagSFHFup_branch) Common_event_tightBtagSFHFup_branch->SetAddress(&Common_event_tightBtagSFHFup_);
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFHFdn*/  Common_event_tightBtagSFHFdn_branch = tree->GetBranch("Common_event_tightBtagSFHFdn");
+/*            Common_event_tightBtagSFHFdn*/  if (Common_event_tightBtagSFHFdn_branch) Common_event_tightBtagSFHFdn_branch->SetAddress(&Common_event_tightBtagSFHFdn_);
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFLFup*/  Common_event_tightBtagSFLFup_branch = tree->GetBranch("Common_event_tightBtagSFLFup");
+/*            Common_event_tightBtagSFLFup*/  if (Common_event_tightBtagSFLFup_branch) Common_event_tightBtagSFLFup_branch->SetAddress(&Common_event_tightBtagSFLFup_);
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFLFdn*/  Common_event_tightBtagSFLFdn_branch = tree->GetBranch("Common_event_tightBtagSFLFdn");
+/*            Common_event_tightBtagSFLFdn*/  if (Common_event_tightBtagSFLFdn_branch) Common_event_tightBtagSFLFdn_branch->SetAddress(&Common_event_tightBtagSFLFdn_);
+//---------------------------------------------------------------------------------
+/*               Common_event_mediumBtagSF*/  Common_event_mediumBtagSF_branch = tree->GetBranch("Common_event_mediumBtagSF");
+/*               Common_event_mediumBtagSF*/  if (Common_event_mediumBtagSF_branch) Common_event_mediumBtagSF_branch->SetAddress(&Common_event_mediumBtagSF_);
+//---------------------------------------------------------------------------------
+/*             Common_event_mediumBtagSFup*/  Common_event_mediumBtagSFup_branch = tree->GetBranch("Common_event_mediumBtagSFup");
+/*             Common_event_mediumBtagSFup*/  if (Common_event_mediumBtagSFup_branch) Common_event_mediumBtagSFup_branch->SetAddress(&Common_event_mediumBtagSFup_);
+//---------------------------------------------------------------------------------
+/*             Common_event_mediumBtagSFdn*/  Common_event_mediumBtagSFdn_branch = tree->GetBranch("Common_event_mediumBtagSFdn");
+/*             Common_event_mediumBtagSFdn*/  if (Common_event_mediumBtagSFdn_branch) Common_event_mediumBtagSFdn_branch->SetAddress(&Common_event_mediumBtagSFdn_);
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFHFup*/  Common_event_mediumBtagSFHFup_branch = tree->GetBranch("Common_event_mediumBtagSFHFup");
+/*           Common_event_mediumBtagSFHFup*/  if (Common_event_mediumBtagSFHFup_branch) Common_event_mediumBtagSFHFup_branch->SetAddress(&Common_event_mediumBtagSFHFup_);
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFHFdn*/  Common_event_mediumBtagSFHFdn_branch = tree->GetBranch("Common_event_mediumBtagSFHFdn");
+/*           Common_event_mediumBtagSFHFdn*/  if (Common_event_mediumBtagSFHFdn_branch) Common_event_mediumBtagSFHFdn_branch->SetAddress(&Common_event_mediumBtagSFHFdn_);
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFLFup*/  Common_event_mediumBtagSFLFup_branch = tree->GetBranch("Common_event_mediumBtagSFLFup");
+/*           Common_event_mediumBtagSFLFup*/  if (Common_event_mediumBtagSFLFup_branch) Common_event_mediumBtagSFLFup_branch->SetAddress(&Common_event_mediumBtagSFLFup_);
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFLFdn*/  Common_event_mediumBtagSFLFdn_branch = tree->GetBranch("Common_event_mediumBtagSFLFdn");
+/*           Common_event_mediumBtagSFLFdn*/  if (Common_event_mediumBtagSFLFdn_branch) Common_event_mediumBtagSFLFdn_branch->SetAddress(&Common_event_mediumBtagSFLFdn_);
+//---------------------------------------------------------------------------------
+/*                Common_event_looseBtagSF*/  Common_event_looseBtagSF_branch = tree->GetBranch("Common_event_looseBtagSF");
+/*                Common_event_looseBtagSF*/  if (Common_event_looseBtagSF_branch) Common_event_looseBtagSF_branch->SetAddress(&Common_event_looseBtagSF_);
+//---------------------------------------------------------------------------------
+/*              Common_event_looseBtagSFup*/  Common_event_looseBtagSFup_branch = tree->GetBranch("Common_event_looseBtagSFup");
+/*              Common_event_looseBtagSFup*/  if (Common_event_looseBtagSFup_branch) Common_event_looseBtagSFup_branch->SetAddress(&Common_event_looseBtagSFup_);
+//---------------------------------------------------------------------------------
+/*              Common_event_looseBtagSFdn*/  Common_event_looseBtagSFdn_branch = tree->GetBranch("Common_event_looseBtagSFdn");
+/*              Common_event_looseBtagSFdn*/  if (Common_event_looseBtagSFdn_branch) Common_event_looseBtagSFdn_branch->SetAddress(&Common_event_looseBtagSFdn_);
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFHFup*/  Common_event_looseBtagSFHFup_branch = tree->GetBranch("Common_event_looseBtagSFHFup");
+/*            Common_event_looseBtagSFHFup*/  if (Common_event_looseBtagSFHFup_branch) Common_event_looseBtagSFHFup_branch->SetAddress(&Common_event_looseBtagSFHFup_);
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFHFdn*/  Common_event_looseBtagSFHFdn_branch = tree->GetBranch("Common_event_looseBtagSFHFdn");
+/*            Common_event_looseBtagSFHFdn*/  if (Common_event_looseBtagSFHFdn_branch) Common_event_looseBtagSFHFdn_branch->SetAddress(&Common_event_looseBtagSFHFdn_);
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFLFup*/  Common_event_looseBtagSFLFup_branch = tree->GetBranch("Common_event_looseBtagSFLFup");
+/*            Common_event_looseBtagSFLFup*/  if (Common_event_looseBtagSFLFup_branch) Common_event_looseBtagSFLFup_branch->SetAddress(&Common_event_looseBtagSFLFup_);
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFLFdn*/  Common_event_looseBtagSFLFdn_branch = tree->GetBranch("Common_event_looseBtagSFLFdn");
+/*            Common_event_looseBtagSFLFdn*/  if (Common_event_looseBtagSFLFdn_branch) Common_event_looseBtagSFLFdn_branch->SetAddress(&Common_event_looseBtagSFLFdn_);
 //---------------------------------------------------------------------------------
 /*                         Common_lep_idxs*/  Common_lep_idxs_branch = tree->GetBranch("Common_lep_idxs");
 /*                         Common_lep_idxs*/  if (Common_lep_idxs_branch) Common_lep_idxs_branch->SetAddress(&Common_lep_idxs_);
@@ -181,11 +331,41 @@ void VVVTree::Init(TTree *tree) {
 /*                   Common_jet_passBtight*/  Common_jet_passBtight_branch = tree->GetBranch("Common_jet_passBtight");
 /*                   Common_jet_passBtight*/  if (Common_jet_passBtight_branch) Common_jet_passBtight_branch->SetAddress(&Common_jet_passBtight_);
 //---------------------------------------------------------------------------------
+/*                           Common_jet_id*/  Common_jet_id_branch = tree->GetBranch("Common_jet_id");
+/*                           Common_jet_id*/  if (Common_jet_id_branch) Common_jet_id_branch->SetAddress(&Common_jet_id_);
+//---------------------------------------------------------------------------------
 /*                Common_jet_overlapfatjet*/  Common_jet_overlapfatjet_branch = tree->GetBranch("Common_jet_overlapfatjet");
 /*                Common_jet_overlapfatjet*/  if (Common_jet_overlapfatjet_branch) Common_jet_overlapfatjet_branch->SetAddress(&Common_jet_overlapfatjet_);
 //---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jesup*/  Common_jet_pt_jesup_branch = tree->GetBranch("Common_jet_pt_jesup");
+/*                     Common_jet_pt_jesup*/  if (Common_jet_pt_jesup_branch) Common_jet_pt_jesup_branch->SetAddress(&Common_jet_pt_jesup_);
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jesdn*/  Common_jet_pt_jesdn_branch = tree->GetBranch("Common_jet_pt_jesdn");
+/*                     Common_jet_pt_jesdn*/  if (Common_jet_pt_jesdn_branch) Common_jet_pt_jesdn_branch->SetAddress(&Common_jet_pt_jesdn_);
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jerup*/  Common_jet_pt_jerup_branch = tree->GetBranch("Common_jet_pt_jerup");
+/*                     Common_jet_pt_jerup*/  if (Common_jet_pt_jerup_branch) Common_jet_pt_jerup_branch->SetAddress(&Common_jet_pt_jerup_);
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jerdn*/  Common_jet_pt_jerdn_branch = tree->GetBranch("Common_jet_pt_jerdn");
+/*                     Common_jet_pt_jerdn*/  if (Common_jet_pt_jerdn_branch) Common_jet_pt_jerdn_branch->SetAddress(&Common_jet_pt_jerdn_);
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jesup*/  Common_jet_mass_jesup_branch = tree->GetBranch("Common_jet_mass_jesup");
+/*                   Common_jet_mass_jesup*/  if (Common_jet_mass_jesup_branch) Common_jet_mass_jesup_branch->SetAddress(&Common_jet_mass_jesup_);
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jesdn*/  Common_jet_mass_jesdn_branch = tree->GetBranch("Common_jet_mass_jesdn");
+/*                   Common_jet_mass_jesdn*/  if (Common_jet_mass_jesdn_branch) Common_jet_mass_jesdn_branch->SetAddress(&Common_jet_mass_jesdn_);
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jerup*/  Common_jet_mass_jerup_branch = tree->GetBranch("Common_jet_mass_jerup");
+/*                   Common_jet_mass_jerup*/  if (Common_jet_mass_jerup_branch) Common_jet_mass_jerup_branch->SetAddress(&Common_jet_mass_jerup_);
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jerdn*/  Common_jet_mass_jerdn_branch = tree->GetBranch("Common_jet_mass_jerdn");
+/*                   Common_jet_mass_jerdn*/  if (Common_jet_mass_jerdn_branch) Common_jet_mass_jerdn_branch->SetAddress(&Common_jet_mass_jerdn_);
+//---------------------------------------------------------------------------------
 /*                      Common_fatjet_idxs*/  Common_fatjet_idxs_branch = tree->GetBranch("Common_fatjet_idxs");
 /*                      Common_fatjet_idxs*/  if (Common_fatjet_idxs_branch) Common_fatjet_idxs_branch->SetAddress(&Common_fatjet_idxs_);
+//---------------------------------------------------------------------------------
+/*                        Common_fatjet_id*/  Common_fatjet_id_branch = tree->GetBranch("Common_fatjet_id");
+/*                        Common_fatjet_id*/  if (Common_fatjet_id_branch) Common_fatjet_id_branch->SetAddress(&Common_fatjet_id_);
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_msoftdrop*/  Common_fatjet_msoftdrop_branch = tree->GetBranch("Common_fatjet_msoftdrop");
 /*                 Common_fatjet_msoftdrop*/  if (Common_fatjet_msoftdrop_branch) Common_fatjet_msoftdrop_branch->SetAddress(&Common_fatjet_msoftdrop_);
@@ -210,6 +390,33 @@ void VVVTree::Init(TTree *tree) {
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_deepMD_bb*/  Common_fatjet_deepMD_bb_branch = tree->GetBranch("Common_fatjet_deepMD_bb");
 /*                 Common_fatjet_deepMD_bb*/  if (Common_fatjet_deepMD_bb_branch) Common_fatjet_deepMD_bb_branch->SetAddress(&Common_fatjet_deepMD_bb_);
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_particleNetMD_W*/  Common_fatjet_particleNetMD_W_branch = tree->GetBranch("Common_fatjet_particleNetMD_W");
+/*           Common_fatjet_particleNetMD_W*/  if (Common_fatjet_particleNetMD_W_branch) Common_fatjet_particleNetMD_W_branch->SetAddress(&Common_fatjet_particleNetMD_W_);
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xqq*/  Common_fatjet_particleNetMD_Xqq_branch = tree->GetBranch("Common_fatjet_particleNetMD_Xqq");
+/*         Common_fatjet_particleNetMD_Xqq*/  if (Common_fatjet_particleNetMD_Xqq_branch) Common_fatjet_particleNetMD_Xqq_branch->SetAddress(&Common_fatjet_particleNetMD_Xqq_);
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xcc*/  Common_fatjet_particleNetMD_Xcc_branch = tree->GetBranch("Common_fatjet_particleNetMD_Xcc");
+/*         Common_fatjet_particleNetMD_Xcc*/  if (Common_fatjet_particleNetMD_Xcc_branch) Common_fatjet_particleNetMD_Xcc_branch->SetAddress(&Common_fatjet_particleNetMD_Xcc_);
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xbb*/  Common_fatjet_particleNetMD_Xbb_branch = tree->GetBranch("Common_fatjet_particleNetMD_Xbb");
+/*         Common_fatjet_particleNetMD_Xbb*/  if (Common_fatjet_particleNetMD_Xbb_branch) Common_fatjet_particleNetMD_Xbb_branch->SetAddress(&Common_fatjet_particleNetMD_Xbb_);
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_QCD*/  Common_fatjet_particleNetMD_QCD_branch = tree->GetBranch("Common_fatjet_particleNetMD_QCD");
+/*         Common_fatjet_particleNetMD_QCD*/  if (Common_fatjet_particleNetMD_QCD_branch) Common_fatjet_particleNetMD_QCD_branch->SetAddress(&Common_fatjet_particleNetMD_QCD_);
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_particleNet_QCD*/  Common_fatjet_particleNet_QCD_branch = tree->GetBranch("Common_fatjet_particleNet_QCD");
+/*           Common_fatjet_particleNet_QCD*/  if (Common_fatjet_particleNet_QCD_branch) Common_fatjet_particleNet_QCD_branch->SetAddress(&Common_fatjet_particleNet_QCD_);
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_W*/  Common_fatjet_particleNet_W_branch = tree->GetBranch("Common_fatjet_particleNet_W");
+/*             Common_fatjet_particleNet_W*/  if (Common_fatjet_particleNet_W_branch) Common_fatjet_particleNet_W_branch->SetAddress(&Common_fatjet_particleNet_W_);
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_Z*/  Common_fatjet_particleNet_Z_branch = tree->GetBranch("Common_fatjet_particleNet_Z");
+/*             Common_fatjet_particleNet_Z*/  if (Common_fatjet_particleNet_Z_branch) Common_fatjet_particleNet_Z_branch->SetAddress(&Common_fatjet_particleNet_Z_);
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_T*/  Common_fatjet_particleNet_T_branch = tree->GetBranch("Common_fatjet_particleNet_T");
+/*             Common_fatjet_particleNet_T*/  if (Common_fatjet_particleNet_T_branch) Common_fatjet_particleNet_T_branch->SetAddress(&Common_fatjet_particleNet_T_);
 //---------------------------------------------------------------------------------
 /*                      Common_fatjet_tau3*/  Common_fatjet_tau3_branch = tree->GetBranch("Common_fatjet_tau3");
 /*                      Common_fatjet_tau3*/  if (Common_fatjet_tau3_branch) Common_fatjet_tau3_branch->SetAddress(&Common_fatjet_tau3_);
@@ -253,6 +460,9 @@ void VVVTree::Init(TTree *tree) {
 /*                        Common_fatjet_WP*/  Common_fatjet_WP_branch = tree->GetBranch("Common_fatjet_WP");
 /*                        Common_fatjet_WP*/  if (Common_fatjet_WP_branch) Common_fatjet_WP_branch->SetAddress(&Common_fatjet_WP_);
 //---------------------------------------------------------------------------------
+/*                     Common_fatjet_WP_MD*/  Common_fatjet_WP_MD_branch = tree->GetBranch("Common_fatjet_WP_MD");
+/*                     Common_fatjet_WP_MD*/  if (Common_fatjet_WP_MD_branch) Common_fatjet_WP_MD_branch->SetAddress(&Common_fatjet_WP_MD_);
+//---------------------------------------------------------------------------------
 /*            Common_fatjet_WP_antimasscut*/  Common_fatjet_WP_antimasscut_branch = tree->GetBranch("Common_fatjet_WP_antimasscut");
 /*            Common_fatjet_WP_antimasscut*/  if (Common_fatjet_WP_antimasscut_branch) Common_fatjet_WP_antimasscut_branch->SetAddress(&Common_fatjet_WP_antimasscut_);
 //---------------------------------------------------------------------------------
@@ -291,6 +501,66 @@ void VVVTree::Init(TTree *tree) {
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_SFupTight*/  Common_fatjet_SFupTight_branch = tree->GetBranch("Common_fatjet_SFupTight");
 /*                 Common_fatjet_SFupTight*/  if (Common_fatjet_SFupTight_branch) Common_fatjet_SFupTight_branch->SetAddress(&Common_fatjet_SFupTight_);
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jesup*/  Common_fatjet_pt_jesup_branch = tree->GetBranch("Common_fatjet_pt_jesup");
+/*                  Common_fatjet_pt_jesup*/  if (Common_fatjet_pt_jesup_branch) Common_fatjet_pt_jesup_branch->SetAddress(&Common_fatjet_pt_jesup_);
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jesdn*/  Common_fatjet_pt_jesdn_branch = tree->GetBranch("Common_fatjet_pt_jesdn");
+/*                  Common_fatjet_pt_jesdn*/  if (Common_fatjet_pt_jesdn_branch) Common_fatjet_pt_jesdn_branch->SetAddress(&Common_fatjet_pt_jesdn_);
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jerup*/  Common_fatjet_pt_jerup_branch = tree->GetBranch("Common_fatjet_pt_jerup");
+/*                  Common_fatjet_pt_jerup*/  if (Common_fatjet_pt_jerup_branch) Common_fatjet_pt_jerup_branch->SetAddress(&Common_fatjet_pt_jerup_);
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jerdn*/  Common_fatjet_pt_jerdn_branch = tree->GetBranch("Common_fatjet_pt_jerdn");
+/*                  Common_fatjet_pt_jerdn*/  if (Common_fatjet_pt_jerdn_branch) Common_fatjet_pt_jerdn_branch->SetAddress(&Common_fatjet_pt_jerdn_);
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jesup*/  Common_fatjet_msoftdrop_jesup_branch = tree->GetBranch("Common_fatjet_msoftdrop_jesup");
+/*           Common_fatjet_msoftdrop_jesup*/  if (Common_fatjet_msoftdrop_jesup_branch) Common_fatjet_msoftdrop_jesup_branch->SetAddress(&Common_fatjet_msoftdrop_jesup_);
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jesdn*/  Common_fatjet_msoftdrop_jesdn_branch = tree->GetBranch("Common_fatjet_msoftdrop_jesdn");
+/*           Common_fatjet_msoftdrop_jesdn*/  if (Common_fatjet_msoftdrop_jesdn_branch) Common_fatjet_msoftdrop_jesdn_branch->SetAddress(&Common_fatjet_msoftdrop_jesdn_);
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jerup*/  Common_fatjet_msoftdrop_jerup_branch = tree->GetBranch("Common_fatjet_msoftdrop_jerup");
+/*           Common_fatjet_msoftdrop_jerup*/  if (Common_fatjet_msoftdrop_jerup_branch) Common_fatjet_msoftdrop_jerup_branch->SetAddress(&Common_fatjet_msoftdrop_jerup_);
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jerdn*/  Common_fatjet_msoftdrop_jerdn_branch = tree->GetBranch("Common_fatjet_msoftdrop_jerdn");
+/*           Common_fatjet_msoftdrop_jerdn*/  if (Common_fatjet_msoftdrop_jerdn_branch) Common_fatjet_msoftdrop_jerdn_branch->SetAddress(&Common_fatjet_msoftdrop_jerdn_);
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmsup*/  Common_fatjet_msoftdrop_jmsup_branch = tree->GetBranch("Common_fatjet_msoftdrop_jmsup");
+/*           Common_fatjet_msoftdrop_jmsup*/  if (Common_fatjet_msoftdrop_jmsup_branch) Common_fatjet_msoftdrop_jmsup_branch->SetAddress(&Common_fatjet_msoftdrop_jmsup_);
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmsdn*/  Common_fatjet_msoftdrop_jmsdn_branch = tree->GetBranch("Common_fatjet_msoftdrop_jmsdn");
+/*           Common_fatjet_msoftdrop_jmsdn*/  if (Common_fatjet_msoftdrop_jmsdn_branch) Common_fatjet_msoftdrop_jmsdn_branch->SetAddress(&Common_fatjet_msoftdrop_jmsdn_);
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmrup*/  Common_fatjet_msoftdrop_jmrup_branch = tree->GetBranch("Common_fatjet_msoftdrop_jmrup");
+/*           Common_fatjet_msoftdrop_jmrup*/  if (Common_fatjet_msoftdrop_jmrup_branch) Common_fatjet_msoftdrop_jmrup_branch->SetAddress(&Common_fatjet_msoftdrop_jmrup_);
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmrdn*/  Common_fatjet_msoftdrop_jmrdn_branch = tree->GetBranch("Common_fatjet_msoftdrop_jmrdn");
+/*           Common_fatjet_msoftdrop_jmrdn*/  if (Common_fatjet_msoftdrop_jmrdn_branch) Common_fatjet_msoftdrop_jmrdn_branch->SetAddress(&Common_fatjet_msoftdrop_jmrdn_);
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jesup*/  Common_fatjet_mass_jesup_branch = tree->GetBranch("Common_fatjet_mass_jesup");
+/*                Common_fatjet_mass_jesup*/  if (Common_fatjet_mass_jesup_branch) Common_fatjet_mass_jesup_branch->SetAddress(&Common_fatjet_mass_jesup_);
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jesdn*/  Common_fatjet_mass_jesdn_branch = tree->GetBranch("Common_fatjet_mass_jesdn");
+/*                Common_fatjet_mass_jesdn*/  if (Common_fatjet_mass_jesdn_branch) Common_fatjet_mass_jesdn_branch->SetAddress(&Common_fatjet_mass_jesdn_);
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jerup*/  Common_fatjet_mass_jerup_branch = tree->GetBranch("Common_fatjet_mass_jerup");
+/*                Common_fatjet_mass_jerup*/  if (Common_fatjet_mass_jerup_branch) Common_fatjet_mass_jerup_branch->SetAddress(&Common_fatjet_mass_jerup_);
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jerdn*/  Common_fatjet_mass_jerdn_branch = tree->GetBranch("Common_fatjet_mass_jerdn");
+/*                Common_fatjet_mass_jerdn*/  if (Common_fatjet_mass_jerdn_branch) Common_fatjet_mass_jerdn_branch->SetAddress(&Common_fatjet_mass_jerdn_);
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmsup*/  Common_fatjet_mass_jmsup_branch = tree->GetBranch("Common_fatjet_mass_jmsup");
+/*                Common_fatjet_mass_jmsup*/  if (Common_fatjet_mass_jmsup_branch) Common_fatjet_mass_jmsup_branch->SetAddress(&Common_fatjet_mass_jmsup_);
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmsdn*/  Common_fatjet_mass_jmsdn_branch = tree->GetBranch("Common_fatjet_mass_jmsdn");
+/*                Common_fatjet_mass_jmsdn*/  if (Common_fatjet_mass_jmsdn_branch) Common_fatjet_mass_jmsdn_branch->SetAddress(&Common_fatjet_mass_jmsdn_);
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmrup*/  Common_fatjet_mass_jmrup_branch = tree->GetBranch("Common_fatjet_mass_jmrup");
+/*                Common_fatjet_mass_jmrup*/  if (Common_fatjet_mass_jmrup_branch) Common_fatjet_mass_jmrup_branch->SetAddress(&Common_fatjet_mass_jmrup_);
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmrdn*/  Common_fatjet_mass_jmrdn_branch = tree->GetBranch("Common_fatjet_mass_jmrdn");
+/*                Common_fatjet_mass_jmrdn*/  if (Common_fatjet_mass_jmrdn_branch) Common_fatjet_mass_jmrdn_branch->SetAddress(&Common_fatjet_mass_jmrdn_);
 //---------------------------------------------------------------------------------
 /*      Common_eventweight_fatjet_SFVLoose*/  Common_eventweight_fatjet_SFVLoose_branch = tree->GetBranch("Common_eventweight_fatjet_SFVLoose");
 /*      Common_eventweight_fatjet_SFVLoose*/  if (Common_eventweight_fatjet_SFVLoose_branch) Common_eventweight_fatjet_SFVLoose_branch->SetAddress(&Common_eventweight_fatjet_SFVLoose_);
@@ -363,6 +633,9 @@ void VVVTree::Init(TTree *tree) {
 //---------------------------------------------------------------------------------
 /*          Common_gen_vvvdecay_taudecayid*/  Common_gen_vvvdecay_taudecayid_branch = tree->GetBranch("Common_gen_vvvdecay_taudecayid");
 /*          Common_gen_vvvdecay_taudecayid*/  if (Common_gen_vvvdecay_taudecayid_branch) Common_gen_vvvdecay_taudecayid_branch->SetAddress(&Common_gen_vvvdecay_taudecayid_);
+//---------------------------------------------------------------------------------
+/*                         Common_isSignal*/  Common_isSignal_branch = tree->GetBranch("Common_isSignal");
+/*                         Common_isSignal*/  if (Common_isSignal_branch) Common_isSignal_branch->SetAddress(&Common_isSignal_);
 //---------------------------------------------------------------------------------
 /*                              Common_n_W*/  Common_n_W_branch = tree->GetBranch("Common_n_W");
 /*                              Common_n_W*/  if (Common_n_W_branch) Common_n_W_branch->SetAddress(&Common_n_W_);
@@ -474,6 +747,26 @@ void VVVTree::GetEntry(unsigned int idx) {
 //---------------------------------------------------------------------------------
 /*              Common_btagWeight_DeepCSVB*/  Common_btagWeight_DeepCSVB_isLoaded = false;
 //---------------------------------------------------------------------------------
+/*                              Common_wgt*/  Common_wgt_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                   Common_event_puWeight*/  Common_event_puWeight_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                 Common_event_puWeightup*/  Common_event_puWeightup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                 Common_event_puWeightdn*/  Common_event_puWeightdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*              Common_event_prefireWeight*/  Common_event_prefireWeight_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*            Common_event_prefireWeightup*/  Common_event_prefireWeightup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*            Common_event_prefireWeightdn*/  Common_event_prefireWeightdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*              Common_event_triggerWeight*/  Common_event_triggerWeight_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*            Common_event_triggerWeightup*/  Common_event_triggerWeightup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*            Common_event_triggerWeightdn*/  Common_event_triggerWeightdn_isLoaded = false;
+//---------------------------------------------------------------------------------
 /*         Common_LHEWeight_mg_reweighting*/  Common_LHEWeight_mg_reweighting_isLoaded = false;
 //---------------------------------------------------------------------------------
 /*Common_HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ*/  Common_HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_isLoaded = false;
@@ -494,6 +787,26 @@ void VVVTree::GetEntry(unsigned int idx) {
 //---------------------------------------------------------------------------------
 /*Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL*/  Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_isLoaded = false;
 //---------------------------------------------------------------------------------
+/*                     Common_HLT_PFHT1050*/  Common_HLT_PFHT1050_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                  Common_HLT_AK8PFJet500*/  Common_HLT_AK8PFJet500_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet380_TrimMass30*/  Common_HLT_AK8PFJet380_TrimMass30_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet360_TrimMass30*/  Common_HLT_AK8PFJet360_TrimMass30_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet400_TrimMass30*/  Common_HLT_AK8PFJet400_TrimMass30_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet420_TrimMass30*/  Common_HLT_AK8PFJet420_TrimMass30_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT750_TrimMass50*/  Common_HLT_AK8PFHT750_TrimMass50_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT800_TrimMass50*/  Common_HLT_AK8PFHT800_TrimMass50_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT850_TrimMass50*/  Common_HLT_AK8PFHT850_TrimMass50_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT900_TrimMass50*/  Common_HLT_AK8PFHT900_TrimMass50_isLoaded = false;
+//---------------------------------------------------------------------------------
 /*                     Common_HLT_DoubleEl*/  Common_HLT_DoubleEl_isLoaded = false;
 //---------------------------------------------------------------------------------
 /*                         Common_HLT_MuEG*/  Common_HLT_MuEG_isLoaded = false;
@@ -512,6 +825,14 @@ void VVVTree::GetEntry(unsigned int idx) {
 //---------------------------------------------------------------------------------
 /*                           Common_met_p4*/  Common_met_p4_isLoaded = false;
 //---------------------------------------------------------------------------------
+/*                     Common_met_p4_jesup*/  Common_met_p4_jesup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jesdn*/  Common_met_p4_jesdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jerup*/  Common_met_p4_jerup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jerdn*/  Common_met_p4_jerdn_isLoaded = false;
+//---------------------------------------------------------------------------------
 /*                      Common_event_lepSF*/  Common_event_lepSF_isLoaded = false;
 //---------------------------------------------------------------------------------
 /*                  Common_event_lepSFelup*/  Common_event_lepSFelup_isLoaded = false;
@@ -521,6 +842,58 @@ void VVVTree::GetEntry(unsigned int idx) {
 /*                  Common_event_lepSFmuup*/  Common_event_lepSFmuup_isLoaded = false;
 //---------------------------------------------------------------------------------
 /*                  Common_event_lepSFmudn*/  Common_event_lepSFmudn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                 Common_event_lepSFTight*/  Common_event_lepSFTight_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFelupTight*/  Common_event_lepSFelupTight_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFeldnTight*/  Common_event_lepSFeldnTight_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFmuupTight*/  Common_event_lepSFmuupTight_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFmudnTight*/  Common_event_lepSFmudnTight_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                Common_event_tightBtagSF*/  Common_event_tightBtagSF_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*              Common_event_tightBtagSFup*/  Common_event_tightBtagSFup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*              Common_event_tightBtagSFdn*/  Common_event_tightBtagSFdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFHFup*/  Common_event_tightBtagSFHFup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFHFdn*/  Common_event_tightBtagSFHFdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFLFup*/  Common_event_tightBtagSFLFup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFLFdn*/  Common_event_tightBtagSFLFdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*               Common_event_mediumBtagSF*/  Common_event_mediumBtagSF_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*             Common_event_mediumBtagSFup*/  Common_event_mediumBtagSFup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*             Common_event_mediumBtagSFdn*/  Common_event_mediumBtagSFdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFHFup*/  Common_event_mediumBtagSFHFup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFHFdn*/  Common_event_mediumBtagSFHFdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFLFup*/  Common_event_mediumBtagSFLFup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFLFdn*/  Common_event_mediumBtagSFLFdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                Common_event_looseBtagSF*/  Common_event_looseBtagSF_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*              Common_event_looseBtagSFup*/  Common_event_looseBtagSFup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*              Common_event_looseBtagSFdn*/  Common_event_looseBtagSFdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFHFup*/  Common_event_looseBtagSFHFup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFHFdn*/  Common_event_looseBtagSFHFdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFLFup*/  Common_event_looseBtagSFLFup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFLFdn*/  Common_event_looseBtagSFLFdn_isLoaded = false;
 //---------------------------------------------------------------------------------
 /*                           Common_lep_p4*/  Common_lep_p4_isLoaded = false;
 //---------------------------------------------------------------------------------
@@ -560,11 +933,31 @@ void VVVTree::GetEntry(unsigned int idx) {
 //---------------------------------------------------------------------------------
 /*                   Common_jet_passBtight*/  Common_jet_passBtight_isLoaded = false;
 //---------------------------------------------------------------------------------
+/*                           Common_jet_id*/  Common_jet_id_isLoaded = false;
+//---------------------------------------------------------------------------------
 /*                Common_jet_overlapfatjet*/  Common_jet_overlapfatjet_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jesup*/  Common_jet_pt_jesup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jesdn*/  Common_jet_pt_jesdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jerup*/  Common_jet_pt_jerup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jerdn*/  Common_jet_pt_jerdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jesup*/  Common_jet_mass_jesup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jesdn*/  Common_jet_mass_jesdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jerup*/  Common_jet_mass_jerup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jerdn*/  Common_jet_mass_jerdn_isLoaded = false;
 //---------------------------------------------------------------------------------
 /*                        Common_fatjet_p4*/  Common_fatjet_p4_isLoaded = false;
 //---------------------------------------------------------------------------------
 /*                      Common_fatjet_idxs*/  Common_fatjet_idxs_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                        Common_fatjet_id*/  Common_fatjet_id_isLoaded = false;
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_msoftdrop*/  Common_fatjet_msoftdrop_isLoaded = false;
 //---------------------------------------------------------------------------------
@@ -581,6 +974,24 @@ void VVVTree::GetEntry(unsigned int idx) {
 /*                    Common_fatjet_deep_T*/  Common_fatjet_deep_T_isLoaded = false;
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_deepMD_bb*/  Common_fatjet_deepMD_bb_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_particleNetMD_W*/  Common_fatjet_particleNetMD_W_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xqq*/  Common_fatjet_particleNetMD_Xqq_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xcc*/  Common_fatjet_particleNetMD_Xcc_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xbb*/  Common_fatjet_particleNetMD_Xbb_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_QCD*/  Common_fatjet_particleNetMD_QCD_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_particleNet_QCD*/  Common_fatjet_particleNet_QCD_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_W*/  Common_fatjet_particleNet_W_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_Z*/  Common_fatjet_particleNet_Z_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_T*/  Common_fatjet_particleNet_T_isLoaded = false;
 //---------------------------------------------------------------------------------
 /*                      Common_fatjet_tau3*/  Common_fatjet_tau3_isLoaded = false;
 //---------------------------------------------------------------------------------
@@ -614,6 +1025,8 @@ void VVVTree::GetEntry(unsigned int idx) {
 //---------------------------------------------------------------------------------
 /*                        Common_fatjet_WP*/  Common_fatjet_WP_isLoaded = false;
 //---------------------------------------------------------------------------------
+/*                     Common_fatjet_WP_MD*/  Common_fatjet_WP_MD_isLoaded = false;
+//---------------------------------------------------------------------------------
 /*            Common_fatjet_WP_antimasscut*/  Common_fatjet_WP_antimasscut_isLoaded = false;
 //---------------------------------------------------------------------------------
 /*                  Common_fatjet_SFVLoose*/  Common_fatjet_SFVLoose_isLoaded = false;
@@ -639,6 +1052,46 @@ void VVVTree::GetEntry(unsigned int idx) {
 /*                Common_fatjet_SFupMedium*/  Common_fatjet_SFupMedium_isLoaded = false;
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_SFupTight*/  Common_fatjet_SFupTight_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jesup*/  Common_fatjet_pt_jesup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jesdn*/  Common_fatjet_pt_jesdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jerup*/  Common_fatjet_pt_jerup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jerdn*/  Common_fatjet_pt_jerdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jesup*/  Common_fatjet_msoftdrop_jesup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jesdn*/  Common_fatjet_msoftdrop_jesdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jerup*/  Common_fatjet_msoftdrop_jerup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jerdn*/  Common_fatjet_msoftdrop_jerdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmsup*/  Common_fatjet_msoftdrop_jmsup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmsdn*/  Common_fatjet_msoftdrop_jmsdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmrup*/  Common_fatjet_msoftdrop_jmrup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmrdn*/  Common_fatjet_msoftdrop_jmrdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jesup*/  Common_fatjet_mass_jesup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jesdn*/  Common_fatjet_mass_jesdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jerup*/  Common_fatjet_mass_jerup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jerdn*/  Common_fatjet_mass_jerdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmsup*/  Common_fatjet_mass_jmsup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmsdn*/  Common_fatjet_mass_jmsdn_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmrup*/  Common_fatjet_mass_jmrup_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmrdn*/  Common_fatjet_mass_jmrdn_isLoaded = false;
 //---------------------------------------------------------------------------------
 /*      Common_eventweight_fatjet_SFVLoose*/  Common_eventweight_fatjet_SFVLoose_isLoaded = false;
 //---------------------------------------------------------------------------------
@@ -691,6 +1144,8 @@ void VVVTree::GetEntry(unsigned int idx) {
 /*                 Common_gen_vvvdecay_p4s*/  Common_gen_vvvdecay_p4s_isLoaded = false;
 //---------------------------------------------------------------------------------
 /*          Common_gen_vvvdecay_taudecayid*/  Common_gen_vvvdecay_taudecayid_isLoaded = false;
+//---------------------------------------------------------------------------------
+/*                         Common_isSignal*/  Common_isSignal_isLoaded = false;
 //---------------------------------------------------------------------------------
 /*                              Common_n_W*/  Common_n_W_isLoaded = false;
 //---------------------------------------------------------------------------------
@@ -777,6 +1232,26 @@ void VVVTree::LoadAllBranches() {
 //---------------------------------------------------------------------------------
 /*              Common_btagWeight_DeepCSVB*/  if (Common_btagWeight_DeepCSVB_branch != 0) Common_btagWeight_DeepCSVB();
 //---------------------------------------------------------------------------------
+/*                              Common_wgt*/  if (Common_wgt_branch != 0) Common_wgt();
+//---------------------------------------------------------------------------------
+/*                   Common_event_puWeight*/  if (Common_event_puWeight_branch != 0) Common_event_puWeight();
+//---------------------------------------------------------------------------------
+/*                 Common_event_puWeightup*/  if (Common_event_puWeightup_branch != 0) Common_event_puWeightup();
+//---------------------------------------------------------------------------------
+/*                 Common_event_puWeightdn*/  if (Common_event_puWeightdn_branch != 0) Common_event_puWeightdn();
+//---------------------------------------------------------------------------------
+/*              Common_event_prefireWeight*/  if (Common_event_prefireWeight_branch != 0) Common_event_prefireWeight();
+//---------------------------------------------------------------------------------
+/*            Common_event_prefireWeightup*/  if (Common_event_prefireWeightup_branch != 0) Common_event_prefireWeightup();
+//---------------------------------------------------------------------------------
+/*            Common_event_prefireWeightdn*/  if (Common_event_prefireWeightdn_branch != 0) Common_event_prefireWeightdn();
+//---------------------------------------------------------------------------------
+/*              Common_event_triggerWeight*/  if (Common_event_triggerWeight_branch != 0) Common_event_triggerWeight();
+//---------------------------------------------------------------------------------
+/*            Common_event_triggerWeightup*/  if (Common_event_triggerWeightup_branch != 0) Common_event_triggerWeightup();
+//---------------------------------------------------------------------------------
+/*            Common_event_triggerWeightdn*/  if (Common_event_triggerWeightdn_branch != 0) Common_event_triggerWeightdn();
+//---------------------------------------------------------------------------------
 /*         Common_LHEWeight_mg_reweighting*/  if (Common_LHEWeight_mg_reweighting_branch != 0) Common_LHEWeight_mg_reweighting();
 //---------------------------------------------------------------------------------
 /*Common_HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ*/  if (Common_HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_branch != 0) Common_HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ();
@@ -797,6 +1272,26 @@ void VVVTree::LoadAllBranches() {
 //---------------------------------------------------------------------------------
 /*Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL*/  if (Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_branch != 0) Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL();
 //---------------------------------------------------------------------------------
+/*                     Common_HLT_PFHT1050*/  if (Common_HLT_PFHT1050_branch != 0) Common_HLT_PFHT1050();
+//---------------------------------------------------------------------------------
+/*                  Common_HLT_AK8PFJet500*/  if (Common_HLT_AK8PFJet500_branch != 0) Common_HLT_AK8PFJet500();
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet380_TrimMass30*/  if (Common_HLT_AK8PFJet380_TrimMass30_branch != 0) Common_HLT_AK8PFJet380_TrimMass30();
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet360_TrimMass30*/  if (Common_HLT_AK8PFJet360_TrimMass30_branch != 0) Common_HLT_AK8PFJet360_TrimMass30();
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet400_TrimMass30*/  if (Common_HLT_AK8PFJet400_TrimMass30_branch != 0) Common_HLT_AK8PFJet400_TrimMass30();
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet420_TrimMass30*/  if (Common_HLT_AK8PFJet420_TrimMass30_branch != 0) Common_HLT_AK8PFJet420_TrimMass30();
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT750_TrimMass50*/  if (Common_HLT_AK8PFHT750_TrimMass50_branch != 0) Common_HLT_AK8PFHT750_TrimMass50();
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT800_TrimMass50*/  if (Common_HLT_AK8PFHT800_TrimMass50_branch != 0) Common_HLT_AK8PFHT800_TrimMass50();
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT850_TrimMass50*/  if (Common_HLT_AK8PFHT850_TrimMass50_branch != 0) Common_HLT_AK8PFHT850_TrimMass50();
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT900_TrimMass50*/  if (Common_HLT_AK8PFHT900_TrimMass50_branch != 0) Common_HLT_AK8PFHT900_TrimMass50();
+//---------------------------------------------------------------------------------
 /*                     Common_HLT_DoubleEl*/  if (Common_HLT_DoubleEl_branch != 0) Common_HLT_DoubleEl();
 //---------------------------------------------------------------------------------
 /*                         Common_HLT_MuEG*/  if (Common_HLT_MuEG_branch != 0) Common_HLT_MuEG();
@@ -815,6 +1310,14 @@ void VVVTree::LoadAllBranches() {
 //---------------------------------------------------------------------------------
 /*                           Common_met_p4*/  if (Common_met_p4_branch != 0) Common_met_p4();
 //---------------------------------------------------------------------------------
+/*                     Common_met_p4_jesup*/  if (Common_met_p4_jesup_branch != 0) Common_met_p4_jesup();
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jesdn*/  if (Common_met_p4_jesdn_branch != 0) Common_met_p4_jesdn();
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jerup*/  if (Common_met_p4_jerup_branch != 0) Common_met_p4_jerup();
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jerdn*/  if (Common_met_p4_jerdn_branch != 0) Common_met_p4_jerdn();
+//---------------------------------------------------------------------------------
 /*                      Common_event_lepSF*/  if (Common_event_lepSF_branch != 0) Common_event_lepSF();
 //---------------------------------------------------------------------------------
 /*                  Common_event_lepSFelup*/  if (Common_event_lepSFelup_branch != 0) Common_event_lepSFelup();
@@ -824,6 +1327,58 @@ void VVVTree::LoadAllBranches() {
 /*                  Common_event_lepSFmuup*/  if (Common_event_lepSFmuup_branch != 0) Common_event_lepSFmuup();
 //---------------------------------------------------------------------------------
 /*                  Common_event_lepSFmudn*/  if (Common_event_lepSFmudn_branch != 0) Common_event_lepSFmudn();
+//---------------------------------------------------------------------------------
+/*                 Common_event_lepSFTight*/  if (Common_event_lepSFTight_branch != 0) Common_event_lepSFTight();
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFelupTight*/  if (Common_event_lepSFelupTight_branch != 0) Common_event_lepSFelupTight();
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFeldnTight*/  if (Common_event_lepSFeldnTight_branch != 0) Common_event_lepSFeldnTight();
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFmuupTight*/  if (Common_event_lepSFmuupTight_branch != 0) Common_event_lepSFmuupTight();
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFmudnTight*/  if (Common_event_lepSFmudnTight_branch != 0) Common_event_lepSFmudnTight();
+//---------------------------------------------------------------------------------
+/*                Common_event_tightBtagSF*/  if (Common_event_tightBtagSF_branch != 0) Common_event_tightBtagSF();
+//---------------------------------------------------------------------------------
+/*              Common_event_tightBtagSFup*/  if (Common_event_tightBtagSFup_branch != 0) Common_event_tightBtagSFup();
+//---------------------------------------------------------------------------------
+/*              Common_event_tightBtagSFdn*/  if (Common_event_tightBtagSFdn_branch != 0) Common_event_tightBtagSFdn();
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFHFup*/  if (Common_event_tightBtagSFHFup_branch != 0) Common_event_tightBtagSFHFup();
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFHFdn*/  if (Common_event_tightBtagSFHFdn_branch != 0) Common_event_tightBtagSFHFdn();
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFLFup*/  if (Common_event_tightBtagSFLFup_branch != 0) Common_event_tightBtagSFLFup();
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFLFdn*/  if (Common_event_tightBtagSFLFdn_branch != 0) Common_event_tightBtagSFLFdn();
+//---------------------------------------------------------------------------------
+/*               Common_event_mediumBtagSF*/  if (Common_event_mediumBtagSF_branch != 0) Common_event_mediumBtagSF();
+//---------------------------------------------------------------------------------
+/*             Common_event_mediumBtagSFup*/  if (Common_event_mediumBtagSFup_branch != 0) Common_event_mediumBtagSFup();
+//---------------------------------------------------------------------------------
+/*             Common_event_mediumBtagSFdn*/  if (Common_event_mediumBtagSFdn_branch != 0) Common_event_mediumBtagSFdn();
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFHFup*/  if (Common_event_mediumBtagSFHFup_branch != 0) Common_event_mediumBtagSFHFup();
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFHFdn*/  if (Common_event_mediumBtagSFHFdn_branch != 0) Common_event_mediumBtagSFHFdn();
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFLFup*/  if (Common_event_mediumBtagSFLFup_branch != 0) Common_event_mediumBtagSFLFup();
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFLFdn*/  if (Common_event_mediumBtagSFLFdn_branch != 0) Common_event_mediumBtagSFLFdn();
+//---------------------------------------------------------------------------------
+/*                Common_event_looseBtagSF*/  if (Common_event_looseBtagSF_branch != 0) Common_event_looseBtagSF();
+//---------------------------------------------------------------------------------
+/*              Common_event_looseBtagSFup*/  if (Common_event_looseBtagSFup_branch != 0) Common_event_looseBtagSFup();
+//---------------------------------------------------------------------------------
+/*              Common_event_looseBtagSFdn*/  if (Common_event_looseBtagSFdn_branch != 0) Common_event_looseBtagSFdn();
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFHFup*/  if (Common_event_looseBtagSFHFup_branch != 0) Common_event_looseBtagSFHFup();
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFHFdn*/  if (Common_event_looseBtagSFHFdn_branch != 0) Common_event_looseBtagSFHFdn();
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFLFup*/  if (Common_event_looseBtagSFLFup_branch != 0) Common_event_looseBtagSFLFup();
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFLFdn*/  if (Common_event_looseBtagSFLFdn_branch != 0) Common_event_looseBtagSFLFdn();
 //---------------------------------------------------------------------------------
 /*                           Common_lep_p4*/  if (Common_lep_p4_branch != 0) Common_lep_p4();
 //---------------------------------------------------------------------------------
@@ -863,11 +1418,31 @@ void VVVTree::LoadAllBranches() {
 //---------------------------------------------------------------------------------
 /*                   Common_jet_passBtight*/  if (Common_jet_passBtight_branch != 0) Common_jet_passBtight();
 //---------------------------------------------------------------------------------
+/*                           Common_jet_id*/  if (Common_jet_id_branch != 0) Common_jet_id();
+//---------------------------------------------------------------------------------
 /*                Common_jet_overlapfatjet*/  if (Common_jet_overlapfatjet_branch != 0) Common_jet_overlapfatjet();
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jesup*/  if (Common_jet_pt_jesup_branch != 0) Common_jet_pt_jesup();
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jesdn*/  if (Common_jet_pt_jesdn_branch != 0) Common_jet_pt_jesdn();
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jerup*/  if (Common_jet_pt_jerup_branch != 0) Common_jet_pt_jerup();
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jerdn*/  if (Common_jet_pt_jerdn_branch != 0) Common_jet_pt_jerdn();
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jesup*/  if (Common_jet_mass_jesup_branch != 0) Common_jet_mass_jesup();
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jesdn*/  if (Common_jet_mass_jesdn_branch != 0) Common_jet_mass_jesdn();
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jerup*/  if (Common_jet_mass_jerup_branch != 0) Common_jet_mass_jerup();
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jerdn*/  if (Common_jet_mass_jerdn_branch != 0) Common_jet_mass_jerdn();
 //---------------------------------------------------------------------------------
 /*                        Common_fatjet_p4*/  if (Common_fatjet_p4_branch != 0) Common_fatjet_p4();
 //---------------------------------------------------------------------------------
 /*                      Common_fatjet_idxs*/  if (Common_fatjet_idxs_branch != 0) Common_fatjet_idxs();
+//---------------------------------------------------------------------------------
+/*                        Common_fatjet_id*/  if (Common_fatjet_id_branch != 0) Common_fatjet_id();
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_msoftdrop*/  if (Common_fatjet_msoftdrop_branch != 0) Common_fatjet_msoftdrop();
 //---------------------------------------------------------------------------------
@@ -884,6 +1459,24 @@ void VVVTree::LoadAllBranches() {
 /*                    Common_fatjet_deep_T*/  if (Common_fatjet_deep_T_branch != 0) Common_fatjet_deep_T();
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_deepMD_bb*/  if (Common_fatjet_deepMD_bb_branch != 0) Common_fatjet_deepMD_bb();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_particleNetMD_W*/  if (Common_fatjet_particleNetMD_W_branch != 0) Common_fatjet_particleNetMD_W();
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xqq*/  if (Common_fatjet_particleNetMD_Xqq_branch != 0) Common_fatjet_particleNetMD_Xqq();
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xcc*/  if (Common_fatjet_particleNetMD_Xcc_branch != 0) Common_fatjet_particleNetMD_Xcc();
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xbb*/  if (Common_fatjet_particleNetMD_Xbb_branch != 0) Common_fatjet_particleNetMD_Xbb();
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_QCD*/  if (Common_fatjet_particleNetMD_QCD_branch != 0) Common_fatjet_particleNetMD_QCD();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_particleNet_QCD*/  if (Common_fatjet_particleNet_QCD_branch != 0) Common_fatjet_particleNet_QCD();
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_W*/  if (Common_fatjet_particleNet_W_branch != 0) Common_fatjet_particleNet_W();
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_Z*/  if (Common_fatjet_particleNet_Z_branch != 0) Common_fatjet_particleNet_Z();
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_T*/  if (Common_fatjet_particleNet_T_branch != 0) Common_fatjet_particleNet_T();
 //---------------------------------------------------------------------------------
 /*                      Common_fatjet_tau3*/  if (Common_fatjet_tau3_branch != 0) Common_fatjet_tau3();
 //---------------------------------------------------------------------------------
@@ -917,6 +1510,8 @@ void VVVTree::LoadAllBranches() {
 //---------------------------------------------------------------------------------
 /*                        Common_fatjet_WP*/  if (Common_fatjet_WP_branch != 0) Common_fatjet_WP();
 //---------------------------------------------------------------------------------
+/*                     Common_fatjet_WP_MD*/  if (Common_fatjet_WP_MD_branch != 0) Common_fatjet_WP_MD();
+//---------------------------------------------------------------------------------
 /*            Common_fatjet_WP_antimasscut*/  if (Common_fatjet_WP_antimasscut_branch != 0) Common_fatjet_WP_antimasscut();
 //---------------------------------------------------------------------------------
 /*                  Common_fatjet_SFVLoose*/  if (Common_fatjet_SFVLoose_branch != 0) Common_fatjet_SFVLoose();
@@ -942,6 +1537,46 @@ void VVVTree::LoadAllBranches() {
 /*                Common_fatjet_SFupMedium*/  if (Common_fatjet_SFupMedium_branch != 0) Common_fatjet_SFupMedium();
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_SFupTight*/  if (Common_fatjet_SFupTight_branch != 0) Common_fatjet_SFupTight();
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jesup*/  if (Common_fatjet_pt_jesup_branch != 0) Common_fatjet_pt_jesup();
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jesdn*/  if (Common_fatjet_pt_jesdn_branch != 0) Common_fatjet_pt_jesdn();
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jerup*/  if (Common_fatjet_pt_jerup_branch != 0) Common_fatjet_pt_jerup();
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jerdn*/  if (Common_fatjet_pt_jerdn_branch != 0) Common_fatjet_pt_jerdn();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jesup*/  if (Common_fatjet_msoftdrop_jesup_branch != 0) Common_fatjet_msoftdrop_jesup();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jesdn*/  if (Common_fatjet_msoftdrop_jesdn_branch != 0) Common_fatjet_msoftdrop_jesdn();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jerup*/  if (Common_fatjet_msoftdrop_jerup_branch != 0) Common_fatjet_msoftdrop_jerup();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jerdn*/  if (Common_fatjet_msoftdrop_jerdn_branch != 0) Common_fatjet_msoftdrop_jerdn();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmsup*/  if (Common_fatjet_msoftdrop_jmsup_branch != 0) Common_fatjet_msoftdrop_jmsup();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmsdn*/  if (Common_fatjet_msoftdrop_jmsdn_branch != 0) Common_fatjet_msoftdrop_jmsdn();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmrup*/  if (Common_fatjet_msoftdrop_jmrup_branch != 0) Common_fatjet_msoftdrop_jmrup();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmrdn*/  if (Common_fatjet_msoftdrop_jmrdn_branch != 0) Common_fatjet_msoftdrop_jmrdn();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jesup*/  if (Common_fatjet_mass_jesup_branch != 0) Common_fatjet_mass_jesup();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jesdn*/  if (Common_fatjet_mass_jesdn_branch != 0) Common_fatjet_mass_jesdn();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jerup*/  if (Common_fatjet_mass_jerup_branch != 0) Common_fatjet_mass_jerup();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jerdn*/  if (Common_fatjet_mass_jerdn_branch != 0) Common_fatjet_mass_jerdn();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmsup*/  if (Common_fatjet_mass_jmsup_branch != 0) Common_fatjet_mass_jmsup();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmsdn*/  if (Common_fatjet_mass_jmsdn_branch != 0) Common_fatjet_mass_jmsdn();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmrup*/  if (Common_fatjet_mass_jmrup_branch != 0) Common_fatjet_mass_jmrup();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmrdn*/  if (Common_fatjet_mass_jmrdn_branch != 0) Common_fatjet_mass_jmrdn();
 //---------------------------------------------------------------------------------
 /*      Common_eventweight_fatjet_SFVLoose*/  if (Common_eventweight_fatjet_SFVLoose_branch != 0) Common_eventweight_fatjet_SFVLoose();
 //---------------------------------------------------------------------------------
@@ -994,6 +1629,8 @@ void VVVTree::LoadAllBranches() {
 /*                 Common_gen_vvvdecay_p4s*/  if (Common_gen_vvvdecay_p4s_branch != 0) Common_gen_vvvdecay_p4s();
 //---------------------------------------------------------------------------------
 /*          Common_gen_vvvdecay_taudecayid*/  if (Common_gen_vvvdecay_taudecayid_branch != 0) Common_gen_vvvdecay_taudecayid();
+//---------------------------------------------------------------------------------
+/*                         Common_isSignal*/  if (Common_isSignal_branch != 0) Common_isSignal();
 //---------------------------------------------------------------------------------
 /*                              Common_n_W*/  if (Common_n_W_branch != 0) Common_n_W();
 //---------------------------------------------------------------------------------
@@ -1150,6 +1787,146 @@ void VVVTree::LoadAllBranches() {
 /*              Common_btagWeight_DeepCSVB*/}
 
 //---------------------------------------------------------------------------------
+/*                              Common_wgt*/const float &VVVTree::Common_wgt() {
+/*                              Common_wgt*/  if (not Common_wgt_isLoaded) {
+/*                              Common_wgt*/    if (Common_wgt_branch != 0) {
+/*                              Common_wgt*/      Common_wgt_branch->GetEntry(index);
+/*                              Common_wgt*/    } else {
+/*                              Common_wgt*/      printf("branch Common_wgt_branch does not exist!\n");
+/*                              Common_wgt*/      exit(1);
+/*                              Common_wgt*/    }
+/*                              Common_wgt*/    Common_wgt_isLoaded = true;
+/*                              Common_wgt*/  }
+/*                              Common_wgt*/  return Common_wgt_;
+/*                              Common_wgt*/}
+
+//---------------------------------------------------------------------------------
+/*                   Common_event_puWeight*/const float &VVVTree::Common_event_puWeight() {
+/*                   Common_event_puWeight*/  if (not Common_event_puWeight_isLoaded) {
+/*                   Common_event_puWeight*/    if (Common_event_puWeight_branch != 0) {
+/*                   Common_event_puWeight*/      Common_event_puWeight_branch->GetEntry(index);
+/*                   Common_event_puWeight*/    } else {
+/*                   Common_event_puWeight*/      printf("branch Common_event_puWeight_branch does not exist!\n");
+/*                   Common_event_puWeight*/      exit(1);
+/*                   Common_event_puWeight*/    }
+/*                   Common_event_puWeight*/    Common_event_puWeight_isLoaded = true;
+/*                   Common_event_puWeight*/  }
+/*                   Common_event_puWeight*/  return Common_event_puWeight_;
+/*                   Common_event_puWeight*/}
+
+//---------------------------------------------------------------------------------
+/*                 Common_event_puWeightup*/const float &VVVTree::Common_event_puWeightup() {
+/*                 Common_event_puWeightup*/  if (not Common_event_puWeightup_isLoaded) {
+/*                 Common_event_puWeightup*/    if (Common_event_puWeightup_branch != 0) {
+/*                 Common_event_puWeightup*/      Common_event_puWeightup_branch->GetEntry(index);
+/*                 Common_event_puWeightup*/    } else {
+/*                 Common_event_puWeightup*/      printf("branch Common_event_puWeightup_branch does not exist!\n");
+/*                 Common_event_puWeightup*/      exit(1);
+/*                 Common_event_puWeightup*/    }
+/*                 Common_event_puWeightup*/    Common_event_puWeightup_isLoaded = true;
+/*                 Common_event_puWeightup*/  }
+/*                 Common_event_puWeightup*/  return Common_event_puWeightup_;
+/*                 Common_event_puWeightup*/}
+
+//---------------------------------------------------------------------------------
+/*                 Common_event_puWeightdn*/const float &VVVTree::Common_event_puWeightdn() {
+/*                 Common_event_puWeightdn*/  if (not Common_event_puWeightdn_isLoaded) {
+/*                 Common_event_puWeightdn*/    if (Common_event_puWeightdn_branch != 0) {
+/*                 Common_event_puWeightdn*/      Common_event_puWeightdn_branch->GetEntry(index);
+/*                 Common_event_puWeightdn*/    } else {
+/*                 Common_event_puWeightdn*/      printf("branch Common_event_puWeightdn_branch does not exist!\n");
+/*                 Common_event_puWeightdn*/      exit(1);
+/*                 Common_event_puWeightdn*/    }
+/*                 Common_event_puWeightdn*/    Common_event_puWeightdn_isLoaded = true;
+/*                 Common_event_puWeightdn*/  }
+/*                 Common_event_puWeightdn*/  return Common_event_puWeightdn_;
+/*                 Common_event_puWeightdn*/}
+
+//---------------------------------------------------------------------------------
+/*              Common_event_prefireWeight*/const float &VVVTree::Common_event_prefireWeight() {
+/*              Common_event_prefireWeight*/  if (not Common_event_prefireWeight_isLoaded) {
+/*              Common_event_prefireWeight*/    if (Common_event_prefireWeight_branch != 0) {
+/*              Common_event_prefireWeight*/      Common_event_prefireWeight_branch->GetEntry(index);
+/*              Common_event_prefireWeight*/    } else {
+/*              Common_event_prefireWeight*/      printf("branch Common_event_prefireWeight_branch does not exist!\n");
+/*              Common_event_prefireWeight*/      exit(1);
+/*              Common_event_prefireWeight*/    }
+/*              Common_event_prefireWeight*/    Common_event_prefireWeight_isLoaded = true;
+/*              Common_event_prefireWeight*/  }
+/*              Common_event_prefireWeight*/  return Common_event_prefireWeight_;
+/*              Common_event_prefireWeight*/}
+
+//---------------------------------------------------------------------------------
+/*            Common_event_prefireWeightup*/const float &VVVTree::Common_event_prefireWeightup() {
+/*            Common_event_prefireWeightup*/  if (not Common_event_prefireWeightup_isLoaded) {
+/*            Common_event_prefireWeightup*/    if (Common_event_prefireWeightup_branch != 0) {
+/*            Common_event_prefireWeightup*/      Common_event_prefireWeightup_branch->GetEntry(index);
+/*            Common_event_prefireWeightup*/    } else {
+/*            Common_event_prefireWeightup*/      printf("branch Common_event_prefireWeightup_branch does not exist!\n");
+/*            Common_event_prefireWeightup*/      exit(1);
+/*            Common_event_prefireWeightup*/    }
+/*            Common_event_prefireWeightup*/    Common_event_prefireWeightup_isLoaded = true;
+/*            Common_event_prefireWeightup*/  }
+/*            Common_event_prefireWeightup*/  return Common_event_prefireWeightup_;
+/*            Common_event_prefireWeightup*/}
+
+//---------------------------------------------------------------------------------
+/*            Common_event_prefireWeightdn*/const float &VVVTree::Common_event_prefireWeightdn() {
+/*            Common_event_prefireWeightdn*/  if (not Common_event_prefireWeightdn_isLoaded) {
+/*            Common_event_prefireWeightdn*/    if (Common_event_prefireWeightdn_branch != 0) {
+/*            Common_event_prefireWeightdn*/      Common_event_prefireWeightdn_branch->GetEntry(index);
+/*            Common_event_prefireWeightdn*/    } else {
+/*            Common_event_prefireWeightdn*/      printf("branch Common_event_prefireWeightdn_branch does not exist!\n");
+/*            Common_event_prefireWeightdn*/      exit(1);
+/*            Common_event_prefireWeightdn*/    }
+/*            Common_event_prefireWeightdn*/    Common_event_prefireWeightdn_isLoaded = true;
+/*            Common_event_prefireWeightdn*/  }
+/*            Common_event_prefireWeightdn*/  return Common_event_prefireWeightdn_;
+/*            Common_event_prefireWeightdn*/}
+
+//---------------------------------------------------------------------------------
+/*              Common_event_triggerWeight*/const float &VVVTree::Common_event_triggerWeight() {
+/*              Common_event_triggerWeight*/  if (not Common_event_triggerWeight_isLoaded) {
+/*              Common_event_triggerWeight*/    if (Common_event_triggerWeight_branch != 0) {
+/*              Common_event_triggerWeight*/      Common_event_triggerWeight_branch->GetEntry(index);
+/*              Common_event_triggerWeight*/    } else {
+/*              Common_event_triggerWeight*/      printf("branch Common_event_triggerWeight_branch does not exist!\n");
+/*              Common_event_triggerWeight*/      exit(1);
+/*              Common_event_triggerWeight*/    }
+/*              Common_event_triggerWeight*/    Common_event_triggerWeight_isLoaded = true;
+/*              Common_event_triggerWeight*/  }
+/*              Common_event_triggerWeight*/  return Common_event_triggerWeight_;
+/*              Common_event_triggerWeight*/}
+
+//---------------------------------------------------------------------------------
+/*            Common_event_triggerWeightup*/const float &VVVTree::Common_event_triggerWeightup() {
+/*            Common_event_triggerWeightup*/  if (not Common_event_triggerWeightup_isLoaded) {
+/*            Common_event_triggerWeightup*/    if (Common_event_triggerWeightup_branch != 0) {
+/*            Common_event_triggerWeightup*/      Common_event_triggerWeightup_branch->GetEntry(index);
+/*            Common_event_triggerWeightup*/    } else {
+/*            Common_event_triggerWeightup*/      printf("branch Common_event_triggerWeightup_branch does not exist!\n");
+/*            Common_event_triggerWeightup*/      exit(1);
+/*            Common_event_triggerWeightup*/    }
+/*            Common_event_triggerWeightup*/    Common_event_triggerWeightup_isLoaded = true;
+/*            Common_event_triggerWeightup*/  }
+/*            Common_event_triggerWeightup*/  return Common_event_triggerWeightup_;
+/*            Common_event_triggerWeightup*/}
+
+//---------------------------------------------------------------------------------
+/*            Common_event_triggerWeightdn*/const float &VVVTree::Common_event_triggerWeightdn() {
+/*            Common_event_triggerWeightdn*/  if (not Common_event_triggerWeightdn_isLoaded) {
+/*            Common_event_triggerWeightdn*/    if (Common_event_triggerWeightdn_branch != 0) {
+/*            Common_event_triggerWeightdn*/      Common_event_triggerWeightdn_branch->GetEntry(index);
+/*            Common_event_triggerWeightdn*/    } else {
+/*            Common_event_triggerWeightdn*/      printf("branch Common_event_triggerWeightdn_branch does not exist!\n");
+/*            Common_event_triggerWeightdn*/      exit(1);
+/*            Common_event_triggerWeightdn*/    }
+/*            Common_event_triggerWeightdn*/    Common_event_triggerWeightdn_isLoaded = true;
+/*            Common_event_triggerWeightdn*/  }
+/*            Common_event_triggerWeightdn*/  return Common_event_triggerWeightdn_;
+/*            Common_event_triggerWeightdn*/}
+
+//---------------------------------------------------------------------------------
 /*         Common_LHEWeight_mg_reweighting*/const vector<float> &VVVTree::Common_LHEWeight_mg_reweighting() {
 /*         Common_LHEWeight_mg_reweighting*/  if (not Common_LHEWeight_mg_reweighting_isLoaded) {
 /*         Common_LHEWeight_mg_reweighting*/    if (Common_LHEWeight_mg_reweighting_branch != 0) {
@@ -1290,6 +2067,146 @@ void VVVTree::LoadAllBranches() {
 /*Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL*/}
 
 //---------------------------------------------------------------------------------
+/*                     Common_HLT_PFHT1050*/const bool &VVVTree::Common_HLT_PFHT1050() {
+/*                     Common_HLT_PFHT1050*/  if (not Common_HLT_PFHT1050_isLoaded) {
+/*                     Common_HLT_PFHT1050*/    if (Common_HLT_PFHT1050_branch != 0) {
+/*                     Common_HLT_PFHT1050*/      Common_HLT_PFHT1050_branch->GetEntry(index);
+/*                     Common_HLT_PFHT1050*/    } else {
+/*                     Common_HLT_PFHT1050*/      printf("branch Common_HLT_PFHT1050_branch does not exist!\n");
+/*                     Common_HLT_PFHT1050*/      exit(1);
+/*                     Common_HLT_PFHT1050*/    }
+/*                     Common_HLT_PFHT1050*/    Common_HLT_PFHT1050_isLoaded = true;
+/*                     Common_HLT_PFHT1050*/  }
+/*                     Common_HLT_PFHT1050*/  return Common_HLT_PFHT1050_;
+/*                     Common_HLT_PFHT1050*/}
+
+//---------------------------------------------------------------------------------
+/*                  Common_HLT_AK8PFJet500*/const bool &VVVTree::Common_HLT_AK8PFJet500() {
+/*                  Common_HLT_AK8PFJet500*/  if (not Common_HLT_AK8PFJet500_isLoaded) {
+/*                  Common_HLT_AK8PFJet500*/    if (Common_HLT_AK8PFJet500_branch != 0) {
+/*                  Common_HLT_AK8PFJet500*/      Common_HLT_AK8PFJet500_branch->GetEntry(index);
+/*                  Common_HLT_AK8PFJet500*/    } else {
+/*                  Common_HLT_AK8PFJet500*/      printf("branch Common_HLT_AK8PFJet500_branch does not exist!\n");
+/*                  Common_HLT_AK8PFJet500*/      exit(1);
+/*                  Common_HLT_AK8PFJet500*/    }
+/*                  Common_HLT_AK8PFJet500*/    Common_HLT_AK8PFJet500_isLoaded = true;
+/*                  Common_HLT_AK8PFJet500*/  }
+/*                  Common_HLT_AK8PFJet500*/  return Common_HLT_AK8PFJet500_;
+/*                  Common_HLT_AK8PFJet500*/}
+
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet380_TrimMass30*/const bool &VVVTree::Common_HLT_AK8PFJet380_TrimMass30() {
+/*       Common_HLT_AK8PFJet380_TrimMass30*/  if (not Common_HLT_AK8PFJet380_TrimMass30_isLoaded) {
+/*       Common_HLT_AK8PFJet380_TrimMass30*/    if (Common_HLT_AK8PFJet380_TrimMass30_branch != 0) {
+/*       Common_HLT_AK8PFJet380_TrimMass30*/      Common_HLT_AK8PFJet380_TrimMass30_branch->GetEntry(index);
+/*       Common_HLT_AK8PFJet380_TrimMass30*/    } else {
+/*       Common_HLT_AK8PFJet380_TrimMass30*/      printf("branch Common_HLT_AK8PFJet380_TrimMass30_branch does not exist!\n");
+/*       Common_HLT_AK8PFJet380_TrimMass30*/      exit(1);
+/*       Common_HLT_AK8PFJet380_TrimMass30*/    }
+/*       Common_HLT_AK8PFJet380_TrimMass30*/    Common_HLT_AK8PFJet380_TrimMass30_isLoaded = true;
+/*       Common_HLT_AK8PFJet380_TrimMass30*/  }
+/*       Common_HLT_AK8PFJet380_TrimMass30*/  return Common_HLT_AK8PFJet380_TrimMass30_;
+/*       Common_HLT_AK8PFJet380_TrimMass30*/}
+
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet360_TrimMass30*/const bool &VVVTree::Common_HLT_AK8PFJet360_TrimMass30() {
+/*       Common_HLT_AK8PFJet360_TrimMass30*/  if (not Common_HLT_AK8PFJet360_TrimMass30_isLoaded) {
+/*       Common_HLT_AK8PFJet360_TrimMass30*/    if (Common_HLT_AK8PFJet360_TrimMass30_branch != 0) {
+/*       Common_HLT_AK8PFJet360_TrimMass30*/      Common_HLT_AK8PFJet360_TrimMass30_branch->GetEntry(index);
+/*       Common_HLT_AK8PFJet360_TrimMass30*/    } else {
+/*       Common_HLT_AK8PFJet360_TrimMass30*/      printf("branch Common_HLT_AK8PFJet360_TrimMass30_branch does not exist!\n");
+/*       Common_HLT_AK8PFJet360_TrimMass30*/      exit(1);
+/*       Common_HLT_AK8PFJet360_TrimMass30*/    }
+/*       Common_HLT_AK8PFJet360_TrimMass30*/    Common_HLT_AK8PFJet360_TrimMass30_isLoaded = true;
+/*       Common_HLT_AK8PFJet360_TrimMass30*/  }
+/*       Common_HLT_AK8PFJet360_TrimMass30*/  return Common_HLT_AK8PFJet360_TrimMass30_;
+/*       Common_HLT_AK8PFJet360_TrimMass30*/}
+
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet400_TrimMass30*/const bool &VVVTree::Common_HLT_AK8PFJet400_TrimMass30() {
+/*       Common_HLT_AK8PFJet400_TrimMass30*/  if (not Common_HLT_AK8PFJet400_TrimMass30_isLoaded) {
+/*       Common_HLT_AK8PFJet400_TrimMass30*/    if (Common_HLT_AK8PFJet400_TrimMass30_branch != 0) {
+/*       Common_HLT_AK8PFJet400_TrimMass30*/      Common_HLT_AK8PFJet400_TrimMass30_branch->GetEntry(index);
+/*       Common_HLT_AK8PFJet400_TrimMass30*/    } else {
+/*       Common_HLT_AK8PFJet400_TrimMass30*/      printf("branch Common_HLT_AK8PFJet400_TrimMass30_branch does not exist!\n");
+/*       Common_HLT_AK8PFJet400_TrimMass30*/      exit(1);
+/*       Common_HLT_AK8PFJet400_TrimMass30*/    }
+/*       Common_HLT_AK8PFJet400_TrimMass30*/    Common_HLT_AK8PFJet400_TrimMass30_isLoaded = true;
+/*       Common_HLT_AK8PFJet400_TrimMass30*/  }
+/*       Common_HLT_AK8PFJet400_TrimMass30*/  return Common_HLT_AK8PFJet400_TrimMass30_;
+/*       Common_HLT_AK8PFJet400_TrimMass30*/}
+
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet420_TrimMass30*/const bool &VVVTree::Common_HLT_AK8PFJet420_TrimMass30() {
+/*       Common_HLT_AK8PFJet420_TrimMass30*/  if (not Common_HLT_AK8PFJet420_TrimMass30_isLoaded) {
+/*       Common_HLT_AK8PFJet420_TrimMass30*/    if (Common_HLT_AK8PFJet420_TrimMass30_branch != 0) {
+/*       Common_HLT_AK8PFJet420_TrimMass30*/      Common_HLT_AK8PFJet420_TrimMass30_branch->GetEntry(index);
+/*       Common_HLT_AK8PFJet420_TrimMass30*/    } else {
+/*       Common_HLT_AK8PFJet420_TrimMass30*/      printf("branch Common_HLT_AK8PFJet420_TrimMass30_branch does not exist!\n");
+/*       Common_HLT_AK8PFJet420_TrimMass30*/      exit(1);
+/*       Common_HLT_AK8PFJet420_TrimMass30*/    }
+/*       Common_HLT_AK8PFJet420_TrimMass30*/    Common_HLT_AK8PFJet420_TrimMass30_isLoaded = true;
+/*       Common_HLT_AK8PFJet420_TrimMass30*/  }
+/*       Common_HLT_AK8PFJet420_TrimMass30*/  return Common_HLT_AK8PFJet420_TrimMass30_;
+/*       Common_HLT_AK8PFJet420_TrimMass30*/}
+
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT750_TrimMass50*/const bool &VVVTree::Common_HLT_AK8PFHT750_TrimMass50() {
+/*        Common_HLT_AK8PFHT750_TrimMass50*/  if (not Common_HLT_AK8PFHT750_TrimMass50_isLoaded) {
+/*        Common_HLT_AK8PFHT750_TrimMass50*/    if (Common_HLT_AK8PFHT750_TrimMass50_branch != 0) {
+/*        Common_HLT_AK8PFHT750_TrimMass50*/      Common_HLT_AK8PFHT750_TrimMass50_branch->GetEntry(index);
+/*        Common_HLT_AK8PFHT750_TrimMass50*/    } else {
+/*        Common_HLT_AK8PFHT750_TrimMass50*/      printf("branch Common_HLT_AK8PFHT750_TrimMass50_branch does not exist!\n");
+/*        Common_HLT_AK8PFHT750_TrimMass50*/      exit(1);
+/*        Common_HLT_AK8PFHT750_TrimMass50*/    }
+/*        Common_HLT_AK8PFHT750_TrimMass50*/    Common_HLT_AK8PFHT750_TrimMass50_isLoaded = true;
+/*        Common_HLT_AK8PFHT750_TrimMass50*/  }
+/*        Common_HLT_AK8PFHT750_TrimMass50*/  return Common_HLT_AK8PFHT750_TrimMass50_;
+/*        Common_HLT_AK8PFHT750_TrimMass50*/}
+
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT800_TrimMass50*/const bool &VVVTree::Common_HLT_AK8PFHT800_TrimMass50() {
+/*        Common_HLT_AK8PFHT800_TrimMass50*/  if (not Common_HLT_AK8PFHT800_TrimMass50_isLoaded) {
+/*        Common_HLT_AK8PFHT800_TrimMass50*/    if (Common_HLT_AK8PFHT800_TrimMass50_branch != 0) {
+/*        Common_HLT_AK8PFHT800_TrimMass50*/      Common_HLT_AK8PFHT800_TrimMass50_branch->GetEntry(index);
+/*        Common_HLT_AK8PFHT800_TrimMass50*/    } else {
+/*        Common_HLT_AK8PFHT800_TrimMass50*/      printf("branch Common_HLT_AK8PFHT800_TrimMass50_branch does not exist!\n");
+/*        Common_HLT_AK8PFHT800_TrimMass50*/      exit(1);
+/*        Common_HLT_AK8PFHT800_TrimMass50*/    }
+/*        Common_HLT_AK8PFHT800_TrimMass50*/    Common_HLT_AK8PFHT800_TrimMass50_isLoaded = true;
+/*        Common_HLT_AK8PFHT800_TrimMass50*/  }
+/*        Common_HLT_AK8PFHT800_TrimMass50*/  return Common_HLT_AK8PFHT800_TrimMass50_;
+/*        Common_HLT_AK8PFHT800_TrimMass50*/}
+
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT850_TrimMass50*/const bool &VVVTree::Common_HLT_AK8PFHT850_TrimMass50() {
+/*        Common_HLT_AK8PFHT850_TrimMass50*/  if (not Common_HLT_AK8PFHT850_TrimMass50_isLoaded) {
+/*        Common_HLT_AK8PFHT850_TrimMass50*/    if (Common_HLT_AK8PFHT850_TrimMass50_branch != 0) {
+/*        Common_HLT_AK8PFHT850_TrimMass50*/      Common_HLT_AK8PFHT850_TrimMass50_branch->GetEntry(index);
+/*        Common_HLT_AK8PFHT850_TrimMass50*/    } else {
+/*        Common_HLT_AK8PFHT850_TrimMass50*/      printf("branch Common_HLT_AK8PFHT850_TrimMass50_branch does not exist!\n");
+/*        Common_HLT_AK8PFHT850_TrimMass50*/      exit(1);
+/*        Common_HLT_AK8PFHT850_TrimMass50*/    }
+/*        Common_HLT_AK8PFHT850_TrimMass50*/    Common_HLT_AK8PFHT850_TrimMass50_isLoaded = true;
+/*        Common_HLT_AK8PFHT850_TrimMass50*/  }
+/*        Common_HLT_AK8PFHT850_TrimMass50*/  return Common_HLT_AK8PFHT850_TrimMass50_;
+/*        Common_HLT_AK8PFHT850_TrimMass50*/}
+
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT900_TrimMass50*/const bool &VVVTree::Common_HLT_AK8PFHT900_TrimMass50() {
+/*        Common_HLT_AK8PFHT900_TrimMass50*/  if (not Common_HLT_AK8PFHT900_TrimMass50_isLoaded) {
+/*        Common_HLT_AK8PFHT900_TrimMass50*/    if (Common_HLT_AK8PFHT900_TrimMass50_branch != 0) {
+/*        Common_HLT_AK8PFHT900_TrimMass50*/      Common_HLT_AK8PFHT900_TrimMass50_branch->GetEntry(index);
+/*        Common_HLT_AK8PFHT900_TrimMass50*/    } else {
+/*        Common_HLT_AK8PFHT900_TrimMass50*/      printf("branch Common_HLT_AK8PFHT900_TrimMass50_branch does not exist!\n");
+/*        Common_HLT_AK8PFHT900_TrimMass50*/      exit(1);
+/*        Common_HLT_AK8PFHT900_TrimMass50*/    }
+/*        Common_HLT_AK8PFHT900_TrimMass50*/    Common_HLT_AK8PFHT900_TrimMass50_isLoaded = true;
+/*        Common_HLT_AK8PFHT900_TrimMass50*/  }
+/*        Common_HLT_AK8PFHT900_TrimMass50*/  return Common_HLT_AK8PFHT900_TrimMass50_;
+/*        Common_HLT_AK8PFHT900_TrimMass50*/}
+
+//---------------------------------------------------------------------------------
 /*                     Common_HLT_DoubleEl*/const bool &VVVTree::Common_HLT_DoubleEl() {
 /*                     Common_HLT_DoubleEl*/  if (not Common_HLT_DoubleEl_isLoaded) {
 /*                     Common_HLT_DoubleEl*/    if (Common_HLT_DoubleEl_branch != 0) {
@@ -1344,7 +2261,6 @@ void VVVTree::LoadAllBranches() {
 /*  Common_pass_duplicate_removal_ee_em_mm*/  }
 /*  Common_pass_duplicate_removal_ee_em_mm*/  return Common_pass_duplicate_removal_ee_em_mm_;
 /*  Common_pass_duplicate_removal_ee_em_mm*/}
-
 //---------------------------------------------------------------------------------
 /*  Common_pass_duplicate_removal_mm_em_ee*/const bool &VVVTree::Common_pass_duplicate_removal_mm_em_ee() {
 /*  Common_pass_duplicate_removal_mm_em_ee*/  if (not Common_pass_duplicate_removal_mm_em_ee_isLoaded) {
@@ -1358,6 +2274,7 @@ void VVVTree::LoadAllBranches() {
 /*  Common_pass_duplicate_removal_mm_em_ee*/  }
 /*  Common_pass_duplicate_removal_mm_em_ee*/  return Common_pass_duplicate_removal_mm_em_ee_;
 /*  Common_pass_duplicate_removal_mm_em_ee*/}
+
 //---------------------------------------------------------------------------------
 /*                        Common_passGoodRun*/const bool &VVVTree::Common_passGoodRun() {
 /*                        Common_passGoodRun*/  if (not Common_passGoodRun_isLoaded) {
@@ -1401,6 +2318,7 @@ void VVVTree::LoadAllBranches() {
 /*                      Common_noiseFlagMC*/  return Common_noiseFlagMC_;
 /*                      Common_noiseFlagMC*/}
 
+
 //---------------------------------------------------------------------------------
 /*                           Common_met_p4*/const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &VVVTree::Common_met_p4() {
 /*                           Common_met_p4*/  if (not Common_met_p4_isLoaded) {
@@ -1414,6 +2332,62 @@ void VVVTree::LoadAllBranches() {
 /*                           Common_met_p4*/  }
 /*                           Common_met_p4*/  return *Common_met_p4_;
 /*                           Common_met_p4*/}
+
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jesup*/const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &VVVTree::Common_met_p4_jesup() {
+/*                     Common_met_p4_jesup*/  if (not Common_met_p4_jesup_isLoaded) {
+/*                     Common_met_p4_jesup*/    if (Common_met_p4_jesup_branch != 0) {
+/*                     Common_met_p4_jesup*/      Common_met_p4_jesup_branch->GetEntry(index);
+/*                     Common_met_p4_jesup*/    } else {
+/*                     Common_met_p4_jesup*/      printf("branch Common_met_p4_jesup_branch does not exist!\n");
+/*                     Common_met_p4_jesup*/      exit(1);
+/*                     Common_met_p4_jesup*/    }
+/*                     Common_met_p4_jesup*/    Common_met_p4_jesup_isLoaded = true;
+/*                     Common_met_p4_jesup*/  }
+/*                     Common_met_p4_jesup*/  return *Common_met_p4_jesup_;
+/*                     Common_met_p4_jesup*/}
+
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jesdn*/const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &VVVTree::Common_met_p4_jesdn() {
+/*                     Common_met_p4_jesdn*/  if (not Common_met_p4_jesdn_isLoaded) {
+/*                     Common_met_p4_jesdn*/    if (Common_met_p4_jesdn_branch != 0) {
+/*                     Common_met_p4_jesdn*/      Common_met_p4_jesdn_branch->GetEntry(index);
+/*                     Common_met_p4_jesdn*/    } else {
+/*                     Common_met_p4_jesdn*/      printf("branch Common_met_p4_jesdn_branch does not exist!\n");
+/*                     Common_met_p4_jesdn*/      exit(1);
+/*                     Common_met_p4_jesdn*/    }
+/*                     Common_met_p4_jesdn*/    Common_met_p4_jesdn_isLoaded = true;
+/*                     Common_met_p4_jesdn*/  }
+/*                     Common_met_p4_jesdn*/  return *Common_met_p4_jesdn_;
+/*                     Common_met_p4_jesdn*/}
+
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jerup*/const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &VVVTree::Common_met_p4_jerup() {
+/*                     Common_met_p4_jerup*/  if (not Common_met_p4_jerup_isLoaded) {
+/*                     Common_met_p4_jerup*/    if (Common_met_p4_jerup_branch != 0) {
+/*                     Common_met_p4_jerup*/      Common_met_p4_jerup_branch->GetEntry(index);
+/*                     Common_met_p4_jerup*/    } else {
+/*                     Common_met_p4_jerup*/      printf("branch Common_met_p4_jerup_branch does not exist!\n");
+/*                     Common_met_p4_jerup*/      exit(1);
+/*                     Common_met_p4_jerup*/    }
+/*                     Common_met_p4_jerup*/    Common_met_p4_jerup_isLoaded = true;
+/*                     Common_met_p4_jerup*/  }
+/*                     Common_met_p4_jerup*/  return *Common_met_p4_jerup_;
+/*                     Common_met_p4_jerup*/}
+
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jerdn*/const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &VVVTree::Common_met_p4_jerdn() {
+/*                     Common_met_p4_jerdn*/  if (not Common_met_p4_jerdn_isLoaded) {
+/*                     Common_met_p4_jerdn*/    if (Common_met_p4_jerdn_branch != 0) {
+/*                     Common_met_p4_jerdn*/      Common_met_p4_jerdn_branch->GetEntry(index);
+/*                     Common_met_p4_jerdn*/    } else {
+/*                     Common_met_p4_jerdn*/      printf("branch Common_met_p4_jerdn_branch does not exist!\n");
+/*                     Common_met_p4_jerdn*/      exit(1);
+/*                     Common_met_p4_jerdn*/    }
+/*                     Common_met_p4_jerdn*/    Common_met_p4_jerdn_isLoaded = true;
+/*                     Common_met_p4_jerdn*/  }
+/*                     Common_met_p4_jerdn*/  return *Common_met_p4_jerdn_;
+/*                     Common_met_p4_jerdn*/}
 
 //---------------------------------------------------------------------------------
 /*                      Common_event_lepSF*/const float &VVVTree::Common_event_lepSF() {
@@ -1484,6 +2458,370 @@ void VVVTree::LoadAllBranches() {
 /*                  Common_event_lepSFmudn*/  }
 /*                  Common_event_lepSFmudn*/  return Common_event_lepSFmudn_;
 /*                  Common_event_lepSFmudn*/}
+
+//---------------------------------------------------------------------------------
+/*                 Common_event_lepSFTight*/const float &VVVTree::Common_event_lepSFTight() {
+/*                 Common_event_lepSFTight*/  if (not Common_event_lepSFTight_isLoaded) {
+/*                 Common_event_lepSFTight*/    if (Common_event_lepSFTight_branch != 0) {
+/*                 Common_event_lepSFTight*/      Common_event_lepSFTight_branch->GetEntry(index);
+/*                 Common_event_lepSFTight*/    } else {
+/*                 Common_event_lepSFTight*/      printf("branch Common_event_lepSFTight_branch does not exist!\n");
+/*                 Common_event_lepSFTight*/      exit(1);
+/*                 Common_event_lepSFTight*/    }
+/*                 Common_event_lepSFTight*/    Common_event_lepSFTight_isLoaded = true;
+/*                 Common_event_lepSFTight*/  }
+/*                 Common_event_lepSFTight*/  return Common_event_lepSFTight_;
+/*                 Common_event_lepSFTight*/}
+
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFelupTight*/const float &VVVTree::Common_event_lepSFelupTight() {
+/*             Common_event_lepSFelupTight*/  if (not Common_event_lepSFelupTight_isLoaded) {
+/*             Common_event_lepSFelupTight*/    if (Common_event_lepSFelupTight_branch != 0) {
+/*             Common_event_lepSFelupTight*/      Common_event_lepSFelupTight_branch->GetEntry(index);
+/*             Common_event_lepSFelupTight*/    } else {
+/*             Common_event_lepSFelupTight*/      printf("branch Common_event_lepSFelupTight_branch does not exist!\n");
+/*             Common_event_lepSFelupTight*/      exit(1);
+/*             Common_event_lepSFelupTight*/    }
+/*             Common_event_lepSFelupTight*/    Common_event_lepSFelupTight_isLoaded = true;
+/*             Common_event_lepSFelupTight*/  }
+/*             Common_event_lepSFelupTight*/  return Common_event_lepSFelupTight_;
+/*             Common_event_lepSFelupTight*/}
+
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFeldnTight*/const float &VVVTree::Common_event_lepSFeldnTight() {
+/*             Common_event_lepSFeldnTight*/  if (not Common_event_lepSFeldnTight_isLoaded) {
+/*             Common_event_lepSFeldnTight*/    if (Common_event_lepSFeldnTight_branch != 0) {
+/*             Common_event_lepSFeldnTight*/      Common_event_lepSFeldnTight_branch->GetEntry(index);
+/*             Common_event_lepSFeldnTight*/    } else {
+/*             Common_event_lepSFeldnTight*/      printf("branch Common_event_lepSFeldnTight_branch does not exist!\n");
+/*             Common_event_lepSFeldnTight*/      exit(1);
+/*             Common_event_lepSFeldnTight*/    }
+/*             Common_event_lepSFeldnTight*/    Common_event_lepSFeldnTight_isLoaded = true;
+/*             Common_event_lepSFeldnTight*/  }
+/*             Common_event_lepSFeldnTight*/  return Common_event_lepSFeldnTight_;
+/*             Common_event_lepSFeldnTight*/}
+
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFmuupTight*/const float &VVVTree::Common_event_lepSFmuupTight() {
+/*             Common_event_lepSFmuupTight*/  if (not Common_event_lepSFmuupTight_isLoaded) {
+/*             Common_event_lepSFmuupTight*/    if (Common_event_lepSFmuupTight_branch != 0) {
+/*             Common_event_lepSFmuupTight*/      Common_event_lepSFmuupTight_branch->GetEntry(index);
+/*             Common_event_lepSFmuupTight*/    } else {
+/*             Common_event_lepSFmuupTight*/      printf("branch Common_event_lepSFmuupTight_branch does not exist!\n");
+/*             Common_event_lepSFmuupTight*/      exit(1);
+/*             Common_event_lepSFmuupTight*/    }
+/*             Common_event_lepSFmuupTight*/    Common_event_lepSFmuupTight_isLoaded = true;
+/*             Common_event_lepSFmuupTight*/  }
+/*             Common_event_lepSFmuupTight*/  return Common_event_lepSFmuupTight_;
+/*             Common_event_lepSFmuupTight*/}
+
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFmudnTight*/const float &VVVTree::Common_event_lepSFmudnTight() {
+/*             Common_event_lepSFmudnTight*/  if (not Common_event_lepSFmudnTight_isLoaded) {
+/*             Common_event_lepSFmudnTight*/    if (Common_event_lepSFmudnTight_branch != 0) {
+/*             Common_event_lepSFmudnTight*/      Common_event_lepSFmudnTight_branch->GetEntry(index);
+/*             Common_event_lepSFmudnTight*/    } else {
+/*             Common_event_lepSFmudnTight*/      printf("branch Common_event_lepSFmudnTight_branch does not exist!\n");
+/*             Common_event_lepSFmudnTight*/      exit(1);
+/*             Common_event_lepSFmudnTight*/    }
+/*             Common_event_lepSFmudnTight*/    Common_event_lepSFmudnTight_isLoaded = true;
+/*             Common_event_lepSFmudnTight*/  }
+/*             Common_event_lepSFmudnTight*/  return Common_event_lepSFmudnTight_;
+/*             Common_event_lepSFmudnTight*/}
+
+//---------------------------------------------------------------------------------
+/*                Common_event_tightBtagSF*/const float &VVVTree::Common_event_tightBtagSF() {
+/*                Common_event_tightBtagSF*/  if (not Common_event_tightBtagSF_isLoaded) {
+/*                Common_event_tightBtagSF*/    if (Common_event_tightBtagSF_branch != 0) {
+/*                Common_event_tightBtagSF*/      Common_event_tightBtagSF_branch->GetEntry(index);
+/*                Common_event_tightBtagSF*/    } else {
+/*                Common_event_tightBtagSF*/      printf("branch Common_event_tightBtagSF_branch does not exist!\n");
+/*                Common_event_tightBtagSF*/      exit(1);
+/*                Common_event_tightBtagSF*/    }
+/*                Common_event_tightBtagSF*/    Common_event_tightBtagSF_isLoaded = true;
+/*                Common_event_tightBtagSF*/  }
+/*                Common_event_tightBtagSF*/  return Common_event_tightBtagSF_;
+/*                Common_event_tightBtagSF*/}
+
+//---------------------------------------------------------------------------------
+/*              Common_event_tightBtagSFup*/const float &VVVTree::Common_event_tightBtagSFup() {
+/*              Common_event_tightBtagSFup*/  if (not Common_event_tightBtagSFup_isLoaded) {
+/*              Common_event_tightBtagSFup*/    if (Common_event_tightBtagSFup_branch != 0) {
+/*              Common_event_tightBtagSFup*/      Common_event_tightBtagSFup_branch->GetEntry(index);
+/*              Common_event_tightBtagSFup*/    } else {
+/*              Common_event_tightBtagSFup*/      printf("branch Common_event_tightBtagSFup_branch does not exist!\n");
+/*              Common_event_tightBtagSFup*/      exit(1);
+/*              Common_event_tightBtagSFup*/    }
+/*              Common_event_tightBtagSFup*/    Common_event_tightBtagSFup_isLoaded = true;
+/*              Common_event_tightBtagSFup*/  }
+/*              Common_event_tightBtagSFup*/  return Common_event_tightBtagSFup_;
+/*              Common_event_tightBtagSFup*/}
+
+//---------------------------------------------------------------------------------
+/*              Common_event_tightBtagSFdn*/const float &VVVTree::Common_event_tightBtagSFdn() {
+/*              Common_event_tightBtagSFdn*/  if (not Common_event_tightBtagSFdn_isLoaded) {
+/*              Common_event_tightBtagSFdn*/    if (Common_event_tightBtagSFdn_branch != 0) {
+/*              Common_event_tightBtagSFdn*/      Common_event_tightBtagSFdn_branch->GetEntry(index);
+/*              Common_event_tightBtagSFdn*/    } else {
+/*              Common_event_tightBtagSFdn*/      printf("branch Common_event_tightBtagSFdn_branch does not exist!\n");
+/*              Common_event_tightBtagSFdn*/      exit(1);
+/*              Common_event_tightBtagSFdn*/    }
+/*              Common_event_tightBtagSFdn*/    Common_event_tightBtagSFdn_isLoaded = true;
+/*              Common_event_tightBtagSFdn*/  }
+/*              Common_event_tightBtagSFdn*/  return Common_event_tightBtagSFdn_;
+/*              Common_event_tightBtagSFdn*/}
+
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFHFup*/const float &VVVTree::Common_event_tightBtagSFHFup() {
+/*            Common_event_tightBtagSFHFup*/  if (not Common_event_tightBtagSFHFup_isLoaded) {
+/*            Common_event_tightBtagSFHFup*/    if (Common_event_tightBtagSFHFup_branch != 0) {
+/*            Common_event_tightBtagSFHFup*/      Common_event_tightBtagSFHFup_branch->GetEntry(index);
+/*            Common_event_tightBtagSFHFup*/    } else {
+/*            Common_event_tightBtagSFHFup*/      printf("branch Common_event_tightBtagSFHFup_branch does not exist!\n");
+/*            Common_event_tightBtagSFHFup*/      exit(1);
+/*            Common_event_tightBtagSFHFup*/    }
+/*            Common_event_tightBtagSFHFup*/    Common_event_tightBtagSFHFup_isLoaded = true;
+/*            Common_event_tightBtagSFHFup*/  }
+/*            Common_event_tightBtagSFHFup*/  return Common_event_tightBtagSFHFup_;
+/*            Common_event_tightBtagSFHFup*/}
+
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFHFdn*/const float &VVVTree::Common_event_tightBtagSFHFdn() {
+/*            Common_event_tightBtagSFHFdn*/  if (not Common_event_tightBtagSFHFdn_isLoaded) {
+/*            Common_event_tightBtagSFHFdn*/    if (Common_event_tightBtagSFHFdn_branch != 0) {
+/*            Common_event_tightBtagSFHFdn*/      Common_event_tightBtagSFHFdn_branch->GetEntry(index);
+/*            Common_event_tightBtagSFHFdn*/    } else {
+/*            Common_event_tightBtagSFHFdn*/      printf("branch Common_event_tightBtagSFHFdn_branch does not exist!\n");
+/*            Common_event_tightBtagSFHFdn*/      exit(1);
+/*            Common_event_tightBtagSFHFdn*/    }
+/*            Common_event_tightBtagSFHFdn*/    Common_event_tightBtagSFHFdn_isLoaded = true;
+/*            Common_event_tightBtagSFHFdn*/  }
+/*            Common_event_tightBtagSFHFdn*/  return Common_event_tightBtagSFHFdn_;
+/*            Common_event_tightBtagSFHFdn*/}
+
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFLFup*/const float &VVVTree::Common_event_tightBtagSFLFup() {
+/*            Common_event_tightBtagSFLFup*/  if (not Common_event_tightBtagSFLFup_isLoaded) {
+/*            Common_event_tightBtagSFLFup*/    if (Common_event_tightBtagSFLFup_branch != 0) {
+/*            Common_event_tightBtagSFLFup*/      Common_event_tightBtagSFLFup_branch->GetEntry(index);
+/*            Common_event_tightBtagSFLFup*/    } else {
+/*            Common_event_tightBtagSFLFup*/      printf("branch Common_event_tightBtagSFLFup_branch does not exist!\n");
+/*            Common_event_tightBtagSFLFup*/      exit(1);
+/*            Common_event_tightBtagSFLFup*/    }
+/*            Common_event_tightBtagSFLFup*/    Common_event_tightBtagSFLFup_isLoaded = true;
+/*            Common_event_tightBtagSFLFup*/  }
+/*            Common_event_tightBtagSFLFup*/  return Common_event_tightBtagSFLFup_;
+/*            Common_event_tightBtagSFLFup*/}
+
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFLFdn*/const float &VVVTree::Common_event_tightBtagSFLFdn() {
+/*            Common_event_tightBtagSFLFdn*/  if (not Common_event_tightBtagSFLFdn_isLoaded) {
+/*            Common_event_tightBtagSFLFdn*/    if (Common_event_tightBtagSFLFdn_branch != 0) {
+/*            Common_event_tightBtagSFLFdn*/      Common_event_tightBtagSFLFdn_branch->GetEntry(index);
+/*            Common_event_tightBtagSFLFdn*/    } else {
+/*            Common_event_tightBtagSFLFdn*/      printf("branch Common_event_tightBtagSFLFdn_branch does not exist!\n");
+/*            Common_event_tightBtagSFLFdn*/      exit(1);
+/*            Common_event_tightBtagSFLFdn*/    }
+/*            Common_event_tightBtagSFLFdn*/    Common_event_tightBtagSFLFdn_isLoaded = true;
+/*            Common_event_tightBtagSFLFdn*/  }
+/*            Common_event_tightBtagSFLFdn*/  return Common_event_tightBtagSFLFdn_;
+/*            Common_event_tightBtagSFLFdn*/}
+
+//---------------------------------------------------------------------------------
+/*               Common_event_mediumBtagSF*/const float &VVVTree::Common_event_mediumBtagSF() {
+/*               Common_event_mediumBtagSF*/  if (not Common_event_mediumBtagSF_isLoaded) {
+/*               Common_event_mediumBtagSF*/    if (Common_event_mediumBtagSF_branch != 0) {
+/*               Common_event_mediumBtagSF*/      Common_event_mediumBtagSF_branch->GetEntry(index);
+/*               Common_event_mediumBtagSF*/    } else {
+/*               Common_event_mediumBtagSF*/      printf("branch Common_event_mediumBtagSF_branch does not exist!\n");
+/*               Common_event_mediumBtagSF*/      exit(1);
+/*               Common_event_mediumBtagSF*/    }
+/*               Common_event_mediumBtagSF*/    Common_event_mediumBtagSF_isLoaded = true;
+/*               Common_event_mediumBtagSF*/  }
+/*               Common_event_mediumBtagSF*/  return Common_event_mediumBtagSF_;
+/*               Common_event_mediumBtagSF*/}
+
+//---------------------------------------------------------------------------------
+/*             Common_event_mediumBtagSFup*/const float &VVVTree::Common_event_mediumBtagSFup() {
+/*             Common_event_mediumBtagSFup*/  if (not Common_event_mediumBtagSFup_isLoaded) {
+/*             Common_event_mediumBtagSFup*/    if (Common_event_mediumBtagSFup_branch != 0) {
+/*             Common_event_mediumBtagSFup*/      Common_event_mediumBtagSFup_branch->GetEntry(index);
+/*             Common_event_mediumBtagSFup*/    } else {
+/*             Common_event_mediumBtagSFup*/      printf("branch Common_event_mediumBtagSFup_branch does not exist!\n");
+/*             Common_event_mediumBtagSFup*/      exit(1);
+/*             Common_event_mediumBtagSFup*/    }
+/*             Common_event_mediumBtagSFup*/    Common_event_mediumBtagSFup_isLoaded = true;
+/*             Common_event_mediumBtagSFup*/  }
+/*             Common_event_mediumBtagSFup*/  return Common_event_mediumBtagSFup_;
+/*             Common_event_mediumBtagSFup*/}
+
+//---------------------------------------------------------------------------------
+/*             Common_event_mediumBtagSFdn*/const float &VVVTree::Common_event_mediumBtagSFdn() {
+/*             Common_event_mediumBtagSFdn*/  if (not Common_event_mediumBtagSFdn_isLoaded) {
+/*             Common_event_mediumBtagSFdn*/    if (Common_event_mediumBtagSFdn_branch != 0) {
+/*             Common_event_mediumBtagSFdn*/      Common_event_mediumBtagSFdn_branch->GetEntry(index);
+/*             Common_event_mediumBtagSFdn*/    } else {
+/*             Common_event_mediumBtagSFdn*/      printf("branch Common_event_mediumBtagSFdn_branch does not exist!\n");
+/*             Common_event_mediumBtagSFdn*/      exit(1);
+/*             Common_event_mediumBtagSFdn*/    }
+/*             Common_event_mediumBtagSFdn*/    Common_event_mediumBtagSFdn_isLoaded = true;
+/*             Common_event_mediumBtagSFdn*/  }
+/*             Common_event_mediumBtagSFdn*/  return Common_event_mediumBtagSFdn_;
+/*             Common_event_mediumBtagSFdn*/}
+
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFHFup*/const float &VVVTree::Common_event_mediumBtagSFHFup() {
+/*           Common_event_mediumBtagSFHFup*/  if (not Common_event_mediumBtagSFHFup_isLoaded) {
+/*           Common_event_mediumBtagSFHFup*/    if (Common_event_mediumBtagSFHFup_branch != 0) {
+/*           Common_event_mediumBtagSFHFup*/      Common_event_mediumBtagSFHFup_branch->GetEntry(index);
+/*           Common_event_mediumBtagSFHFup*/    } else {
+/*           Common_event_mediumBtagSFHFup*/      printf("branch Common_event_mediumBtagSFHFup_branch does not exist!\n");
+/*           Common_event_mediumBtagSFHFup*/      exit(1);
+/*           Common_event_mediumBtagSFHFup*/    }
+/*           Common_event_mediumBtagSFHFup*/    Common_event_mediumBtagSFHFup_isLoaded = true;
+/*           Common_event_mediumBtagSFHFup*/  }
+/*           Common_event_mediumBtagSFHFup*/  return Common_event_mediumBtagSFHFup_;
+/*           Common_event_mediumBtagSFHFup*/}
+
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFHFdn*/const float &VVVTree::Common_event_mediumBtagSFHFdn() {
+/*           Common_event_mediumBtagSFHFdn*/  if (not Common_event_mediumBtagSFHFdn_isLoaded) {
+/*           Common_event_mediumBtagSFHFdn*/    if (Common_event_mediumBtagSFHFdn_branch != 0) {
+/*           Common_event_mediumBtagSFHFdn*/      Common_event_mediumBtagSFHFdn_branch->GetEntry(index);
+/*           Common_event_mediumBtagSFHFdn*/    } else {
+/*           Common_event_mediumBtagSFHFdn*/      printf("branch Common_event_mediumBtagSFHFdn_branch does not exist!\n");
+/*           Common_event_mediumBtagSFHFdn*/      exit(1);
+/*           Common_event_mediumBtagSFHFdn*/    }
+/*           Common_event_mediumBtagSFHFdn*/    Common_event_mediumBtagSFHFdn_isLoaded = true;
+/*           Common_event_mediumBtagSFHFdn*/  }
+/*           Common_event_mediumBtagSFHFdn*/  return Common_event_mediumBtagSFHFdn_;
+/*           Common_event_mediumBtagSFHFdn*/}
+
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFLFup*/const float &VVVTree::Common_event_mediumBtagSFLFup() {
+/*           Common_event_mediumBtagSFLFup*/  if (not Common_event_mediumBtagSFLFup_isLoaded) {
+/*           Common_event_mediumBtagSFLFup*/    if (Common_event_mediumBtagSFLFup_branch != 0) {
+/*           Common_event_mediumBtagSFLFup*/      Common_event_mediumBtagSFLFup_branch->GetEntry(index);
+/*           Common_event_mediumBtagSFLFup*/    } else {
+/*           Common_event_mediumBtagSFLFup*/      printf("branch Common_event_mediumBtagSFLFup_branch does not exist!\n");
+/*           Common_event_mediumBtagSFLFup*/      exit(1);
+/*           Common_event_mediumBtagSFLFup*/    }
+/*           Common_event_mediumBtagSFLFup*/    Common_event_mediumBtagSFLFup_isLoaded = true;
+/*           Common_event_mediumBtagSFLFup*/  }
+/*           Common_event_mediumBtagSFLFup*/  return Common_event_mediumBtagSFLFup_;
+/*           Common_event_mediumBtagSFLFup*/}
+
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFLFdn*/const float &VVVTree::Common_event_mediumBtagSFLFdn() {
+/*           Common_event_mediumBtagSFLFdn*/  if (not Common_event_mediumBtagSFLFdn_isLoaded) {
+/*           Common_event_mediumBtagSFLFdn*/    if (Common_event_mediumBtagSFLFdn_branch != 0) {
+/*           Common_event_mediumBtagSFLFdn*/      Common_event_mediumBtagSFLFdn_branch->GetEntry(index);
+/*           Common_event_mediumBtagSFLFdn*/    } else {
+/*           Common_event_mediumBtagSFLFdn*/      printf("branch Common_event_mediumBtagSFLFdn_branch does not exist!\n");
+/*           Common_event_mediumBtagSFLFdn*/      exit(1);
+/*           Common_event_mediumBtagSFLFdn*/    }
+/*           Common_event_mediumBtagSFLFdn*/    Common_event_mediumBtagSFLFdn_isLoaded = true;
+/*           Common_event_mediumBtagSFLFdn*/  }
+/*           Common_event_mediumBtagSFLFdn*/  return Common_event_mediumBtagSFLFdn_;
+/*           Common_event_mediumBtagSFLFdn*/}
+
+//---------------------------------------------------------------------------------
+/*                Common_event_looseBtagSF*/const float &VVVTree::Common_event_looseBtagSF() {
+/*                Common_event_looseBtagSF*/  if (not Common_event_looseBtagSF_isLoaded) {
+/*                Common_event_looseBtagSF*/    if (Common_event_looseBtagSF_branch != 0) {
+/*                Common_event_looseBtagSF*/      Common_event_looseBtagSF_branch->GetEntry(index);
+/*                Common_event_looseBtagSF*/    } else {
+/*                Common_event_looseBtagSF*/      printf("branch Common_event_looseBtagSF_branch does not exist!\n");
+/*                Common_event_looseBtagSF*/      exit(1);
+/*                Common_event_looseBtagSF*/    }
+/*                Common_event_looseBtagSF*/    Common_event_looseBtagSF_isLoaded = true;
+/*                Common_event_looseBtagSF*/  }
+/*                Common_event_looseBtagSF*/  return Common_event_looseBtagSF_;
+/*                Common_event_looseBtagSF*/}
+
+//---------------------------------------------------------------------------------
+/*              Common_event_looseBtagSFup*/const float &VVVTree::Common_event_looseBtagSFup() {
+/*              Common_event_looseBtagSFup*/  if (not Common_event_looseBtagSFup_isLoaded) {
+/*              Common_event_looseBtagSFup*/    if (Common_event_looseBtagSFup_branch != 0) {
+/*              Common_event_looseBtagSFup*/      Common_event_looseBtagSFup_branch->GetEntry(index);
+/*              Common_event_looseBtagSFup*/    } else {
+/*              Common_event_looseBtagSFup*/      printf("branch Common_event_looseBtagSFup_branch does not exist!\n");
+/*              Common_event_looseBtagSFup*/      exit(1);
+/*              Common_event_looseBtagSFup*/    }
+/*              Common_event_looseBtagSFup*/    Common_event_looseBtagSFup_isLoaded = true;
+/*              Common_event_looseBtagSFup*/  }
+/*              Common_event_looseBtagSFup*/  return Common_event_looseBtagSFup_;
+/*              Common_event_looseBtagSFup*/}
+
+//---------------------------------------------------------------------------------
+/*              Common_event_looseBtagSFdn*/const float &VVVTree::Common_event_looseBtagSFdn() {
+/*              Common_event_looseBtagSFdn*/  if (not Common_event_looseBtagSFdn_isLoaded) {
+/*              Common_event_looseBtagSFdn*/    if (Common_event_looseBtagSFdn_branch != 0) {
+/*              Common_event_looseBtagSFdn*/      Common_event_looseBtagSFdn_branch->GetEntry(index);
+/*              Common_event_looseBtagSFdn*/    } else {
+/*              Common_event_looseBtagSFdn*/      printf("branch Common_event_looseBtagSFdn_branch does not exist!\n");
+/*              Common_event_looseBtagSFdn*/      exit(1);
+/*              Common_event_looseBtagSFdn*/    }
+/*              Common_event_looseBtagSFdn*/    Common_event_looseBtagSFdn_isLoaded = true;
+/*              Common_event_looseBtagSFdn*/  }
+/*              Common_event_looseBtagSFdn*/  return Common_event_looseBtagSFdn_;
+/*              Common_event_looseBtagSFdn*/}
+
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFHFup*/const float &VVVTree::Common_event_looseBtagSFHFup() {
+/*            Common_event_looseBtagSFHFup*/  if (not Common_event_looseBtagSFHFup_isLoaded) {
+/*            Common_event_looseBtagSFHFup*/    if (Common_event_looseBtagSFHFup_branch != 0) {
+/*            Common_event_looseBtagSFHFup*/      Common_event_looseBtagSFHFup_branch->GetEntry(index);
+/*            Common_event_looseBtagSFHFup*/    } else {
+/*            Common_event_looseBtagSFHFup*/      printf("branch Common_event_looseBtagSFHFup_branch does not exist!\n");
+/*            Common_event_looseBtagSFHFup*/      exit(1);
+/*            Common_event_looseBtagSFHFup*/    }
+/*            Common_event_looseBtagSFHFup*/    Common_event_looseBtagSFHFup_isLoaded = true;
+/*            Common_event_looseBtagSFHFup*/  }
+/*            Common_event_looseBtagSFHFup*/  return Common_event_looseBtagSFHFup_;
+/*            Common_event_looseBtagSFHFup*/}
+
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFHFdn*/const float &VVVTree::Common_event_looseBtagSFHFdn() {
+/*            Common_event_looseBtagSFHFdn*/  if (not Common_event_looseBtagSFHFdn_isLoaded) {
+/*            Common_event_looseBtagSFHFdn*/    if (Common_event_looseBtagSFHFdn_branch != 0) {
+/*            Common_event_looseBtagSFHFdn*/      Common_event_looseBtagSFHFdn_branch->GetEntry(index);
+/*            Common_event_looseBtagSFHFdn*/    } else {
+/*            Common_event_looseBtagSFHFdn*/      printf("branch Common_event_looseBtagSFHFdn_branch does not exist!\n");
+/*            Common_event_looseBtagSFHFdn*/      exit(1);
+/*            Common_event_looseBtagSFHFdn*/    }
+/*            Common_event_looseBtagSFHFdn*/    Common_event_looseBtagSFHFdn_isLoaded = true;
+/*            Common_event_looseBtagSFHFdn*/  }
+/*            Common_event_looseBtagSFHFdn*/  return Common_event_looseBtagSFHFdn_;
+/*            Common_event_looseBtagSFHFdn*/}
+
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFLFup*/const float &VVVTree::Common_event_looseBtagSFLFup() {
+/*            Common_event_looseBtagSFLFup*/  if (not Common_event_looseBtagSFLFup_isLoaded) {
+/*            Common_event_looseBtagSFLFup*/    if (Common_event_looseBtagSFLFup_branch != 0) {
+/*            Common_event_looseBtagSFLFup*/      Common_event_looseBtagSFLFup_branch->GetEntry(index);
+/*            Common_event_looseBtagSFLFup*/    } else {
+/*            Common_event_looseBtagSFLFup*/      printf("branch Common_event_looseBtagSFLFup_branch does not exist!\n");
+/*            Common_event_looseBtagSFLFup*/      exit(1);
+/*            Common_event_looseBtagSFLFup*/    }
+/*            Common_event_looseBtagSFLFup*/    Common_event_looseBtagSFLFup_isLoaded = true;
+/*            Common_event_looseBtagSFLFup*/  }
+/*            Common_event_looseBtagSFLFup*/  return Common_event_looseBtagSFLFup_;
+/*            Common_event_looseBtagSFLFup*/}
+
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFLFdn*/const float &VVVTree::Common_event_looseBtagSFLFdn() {
+/*            Common_event_looseBtagSFLFdn*/  if (not Common_event_looseBtagSFLFdn_isLoaded) {
+/*            Common_event_looseBtagSFLFdn*/    if (Common_event_looseBtagSFLFdn_branch != 0) {
+/*            Common_event_looseBtagSFLFdn*/      Common_event_looseBtagSFLFdn_branch->GetEntry(index);
+/*            Common_event_looseBtagSFLFdn*/    } else {
+/*            Common_event_looseBtagSFLFdn*/      printf("branch Common_event_looseBtagSFLFdn_branch does not exist!\n");
+/*            Common_event_looseBtagSFLFdn*/      exit(1);
+/*            Common_event_looseBtagSFLFdn*/    }
+/*            Common_event_looseBtagSFLFdn*/    Common_event_looseBtagSFLFdn_isLoaded = true;
+/*            Common_event_looseBtagSFLFdn*/  }
+/*            Common_event_looseBtagSFLFdn*/  return Common_event_looseBtagSFLFdn_;
+/*            Common_event_looseBtagSFLFdn*/}
 
 //---------------------------------------------------------------------------------
 /*                           Common_lep_p4*/const vector<ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > > &VVVTree::Common_lep_p4() {
@@ -1752,6 +3090,20 @@ void VVVTree::LoadAllBranches() {
 /*                   Common_jet_passBtight*/}
 
 //---------------------------------------------------------------------------------
+/*                           Common_jet_id*/const vector<int> &VVVTree::Common_jet_id() {
+/*                           Common_jet_id*/  if (not Common_jet_id_isLoaded) {
+/*                           Common_jet_id*/    if (Common_jet_id_branch != 0) {
+/*                           Common_jet_id*/      Common_jet_id_branch->GetEntry(index);
+/*                           Common_jet_id*/    } else {
+/*                           Common_jet_id*/      printf("branch Common_jet_id_branch does not exist!\n");
+/*                           Common_jet_id*/      exit(1);
+/*                           Common_jet_id*/    }
+/*                           Common_jet_id*/    Common_jet_id_isLoaded = true;
+/*                           Common_jet_id*/  }
+/*                           Common_jet_id*/  return *Common_jet_id_;
+/*                           Common_jet_id*/}
+
+//---------------------------------------------------------------------------------
 /*                Common_jet_overlapfatjet*/const vector<int> &VVVTree::Common_jet_overlapfatjet() {
 /*                Common_jet_overlapfatjet*/  if (not Common_jet_overlapfatjet_isLoaded) {
 /*                Common_jet_overlapfatjet*/    if (Common_jet_overlapfatjet_branch != 0) {
@@ -1764,6 +3116,118 @@ void VVVTree::LoadAllBranches() {
 /*                Common_jet_overlapfatjet*/  }
 /*                Common_jet_overlapfatjet*/  return *Common_jet_overlapfatjet_;
 /*                Common_jet_overlapfatjet*/}
+
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jesup*/const vector<float> &VVVTree::Common_jet_pt_jesup() {
+/*                     Common_jet_pt_jesup*/  if (not Common_jet_pt_jesup_isLoaded) {
+/*                     Common_jet_pt_jesup*/    if (Common_jet_pt_jesup_branch != 0) {
+/*                     Common_jet_pt_jesup*/      Common_jet_pt_jesup_branch->GetEntry(index);
+/*                     Common_jet_pt_jesup*/    } else {
+/*                     Common_jet_pt_jesup*/      printf("branch Common_jet_pt_jesup_branch does not exist!\n");
+/*                     Common_jet_pt_jesup*/      exit(1);
+/*                     Common_jet_pt_jesup*/    }
+/*                     Common_jet_pt_jesup*/    Common_jet_pt_jesup_isLoaded = true;
+/*                     Common_jet_pt_jesup*/  }
+/*                     Common_jet_pt_jesup*/  return *Common_jet_pt_jesup_;
+/*                     Common_jet_pt_jesup*/}
+
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jesdn*/const vector<float> &VVVTree::Common_jet_pt_jesdn() {
+/*                     Common_jet_pt_jesdn*/  if (not Common_jet_pt_jesdn_isLoaded) {
+/*                     Common_jet_pt_jesdn*/    if (Common_jet_pt_jesdn_branch != 0) {
+/*                     Common_jet_pt_jesdn*/      Common_jet_pt_jesdn_branch->GetEntry(index);
+/*                     Common_jet_pt_jesdn*/    } else {
+/*                     Common_jet_pt_jesdn*/      printf("branch Common_jet_pt_jesdn_branch does not exist!\n");
+/*                     Common_jet_pt_jesdn*/      exit(1);
+/*                     Common_jet_pt_jesdn*/    }
+/*                     Common_jet_pt_jesdn*/    Common_jet_pt_jesdn_isLoaded = true;
+/*                     Common_jet_pt_jesdn*/  }
+/*                     Common_jet_pt_jesdn*/  return *Common_jet_pt_jesdn_;
+/*                     Common_jet_pt_jesdn*/}
+
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jerup*/const vector<float> &VVVTree::Common_jet_pt_jerup() {
+/*                     Common_jet_pt_jerup*/  if (not Common_jet_pt_jerup_isLoaded) {
+/*                     Common_jet_pt_jerup*/    if (Common_jet_pt_jerup_branch != 0) {
+/*                     Common_jet_pt_jerup*/      Common_jet_pt_jerup_branch->GetEntry(index);
+/*                     Common_jet_pt_jerup*/    } else {
+/*                     Common_jet_pt_jerup*/      printf("branch Common_jet_pt_jerup_branch does not exist!\n");
+/*                     Common_jet_pt_jerup*/      exit(1);
+/*                     Common_jet_pt_jerup*/    }
+/*                     Common_jet_pt_jerup*/    Common_jet_pt_jerup_isLoaded = true;
+/*                     Common_jet_pt_jerup*/  }
+/*                     Common_jet_pt_jerup*/  return *Common_jet_pt_jerup_;
+/*                     Common_jet_pt_jerup*/}
+
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jerdn*/const vector<float> &VVVTree::Common_jet_pt_jerdn() {
+/*                     Common_jet_pt_jerdn*/  if (not Common_jet_pt_jerdn_isLoaded) {
+/*                     Common_jet_pt_jerdn*/    if (Common_jet_pt_jerdn_branch != 0) {
+/*                     Common_jet_pt_jerdn*/      Common_jet_pt_jerdn_branch->GetEntry(index);
+/*                     Common_jet_pt_jerdn*/    } else {
+/*                     Common_jet_pt_jerdn*/      printf("branch Common_jet_pt_jerdn_branch does not exist!\n");
+/*                     Common_jet_pt_jerdn*/      exit(1);
+/*                     Common_jet_pt_jerdn*/    }
+/*                     Common_jet_pt_jerdn*/    Common_jet_pt_jerdn_isLoaded = true;
+/*                     Common_jet_pt_jerdn*/  }
+/*                     Common_jet_pt_jerdn*/  return *Common_jet_pt_jerdn_;
+/*                     Common_jet_pt_jerdn*/}
+
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jesup*/const vector<float> &VVVTree::Common_jet_mass_jesup() {
+/*                   Common_jet_mass_jesup*/  if (not Common_jet_mass_jesup_isLoaded) {
+/*                   Common_jet_mass_jesup*/    if (Common_jet_mass_jesup_branch != 0) {
+/*                   Common_jet_mass_jesup*/      Common_jet_mass_jesup_branch->GetEntry(index);
+/*                   Common_jet_mass_jesup*/    } else {
+/*                   Common_jet_mass_jesup*/      printf("branch Common_jet_mass_jesup_branch does not exist!\n");
+/*                   Common_jet_mass_jesup*/      exit(1);
+/*                   Common_jet_mass_jesup*/    }
+/*                   Common_jet_mass_jesup*/    Common_jet_mass_jesup_isLoaded = true;
+/*                   Common_jet_mass_jesup*/  }
+/*                   Common_jet_mass_jesup*/  return *Common_jet_mass_jesup_;
+/*                   Common_jet_mass_jesup*/}
+
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jesdn*/const vector<float> &VVVTree::Common_jet_mass_jesdn() {
+/*                   Common_jet_mass_jesdn*/  if (not Common_jet_mass_jesdn_isLoaded) {
+/*                   Common_jet_mass_jesdn*/    if (Common_jet_mass_jesdn_branch != 0) {
+/*                   Common_jet_mass_jesdn*/      Common_jet_mass_jesdn_branch->GetEntry(index);
+/*                   Common_jet_mass_jesdn*/    } else {
+/*                   Common_jet_mass_jesdn*/      printf("branch Common_jet_mass_jesdn_branch does not exist!\n");
+/*                   Common_jet_mass_jesdn*/      exit(1);
+/*                   Common_jet_mass_jesdn*/    }
+/*                   Common_jet_mass_jesdn*/    Common_jet_mass_jesdn_isLoaded = true;
+/*                   Common_jet_mass_jesdn*/  }
+/*                   Common_jet_mass_jesdn*/  return *Common_jet_mass_jesdn_;
+/*                   Common_jet_mass_jesdn*/}
+
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jerup*/const vector<float> &VVVTree::Common_jet_mass_jerup() {
+/*                   Common_jet_mass_jerup*/  if (not Common_jet_mass_jerup_isLoaded) {
+/*                   Common_jet_mass_jerup*/    if (Common_jet_mass_jerup_branch != 0) {
+/*                   Common_jet_mass_jerup*/      Common_jet_mass_jerup_branch->GetEntry(index);
+/*                   Common_jet_mass_jerup*/    } else {
+/*                   Common_jet_mass_jerup*/      printf("branch Common_jet_mass_jerup_branch does not exist!\n");
+/*                   Common_jet_mass_jerup*/      exit(1);
+/*                   Common_jet_mass_jerup*/    }
+/*                   Common_jet_mass_jerup*/    Common_jet_mass_jerup_isLoaded = true;
+/*                   Common_jet_mass_jerup*/  }
+/*                   Common_jet_mass_jerup*/  return *Common_jet_mass_jerup_;
+/*                   Common_jet_mass_jerup*/}
+
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jerdn*/const vector<float> &VVVTree::Common_jet_mass_jerdn() {
+/*                   Common_jet_mass_jerdn*/  if (not Common_jet_mass_jerdn_isLoaded) {
+/*                   Common_jet_mass_jerdn*/    if (Common_jet_mass_jerdn_branch != 0) {
+/*                   Common_jet_mass_jerdn*/      Common_jet_mass_jerdn_branch->GetEntry(index);
+/*                   Common_jet_mass_jerdn*/    } else {
+/*                   Common_jet_mass_jerdn*/      printf("branch Common_jet_mass_jerdn_branch does not exist!\n");
+/*                   Common_jet_mass_jerdn*/      exit(1);
+/*                   Common_jet_mass_jerdn*/    }
+/*                   Common_jet_mass_jerdn*/    Common_jet_mass_jerdn_isLoaded = true;
+/*                   Common_jet_mass_jerdn*/  }
+/*                   Common_jet_mass_jerdn*/  return *Common_jet_mass_jerdn_;
+/*                   Common_jet_mass_jerdn*/}
 
 //---------------------------------------------------------------------------------
 /*                        Common_fatjet_p4*/const vector<ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > > &VVVTree::Common_fatjet_p4() {
@@ -1792,6 +3256,20 @@ void VVVTree::LoadAllBranches() {
 /*                      Common_fatjet_idxs*/  }
 /*                      Common_fatjet_idxs*/  return *Common_fatjet_idxs_;
 /*                      Common_fatjet_idxs*/}
+
+//---------------------------------------------------------------------------------
+/*                        Common_fatjet_id*/const vector<int> &VVVTree::Common_fatjet_id() {
+/*                        Common_fatjet_id*/  if (not Common_fatjet_id_isLoaded) {
+/*                        Common_fatjet_id*/    if (Common_fatjet_id_branch != 0) {
+/*                        Common_fatjet_id*/      Common_fatjet_id_branch->GetEntry(index);
+/*                        Common_fatjet_id*/    } else {
+/*                        Common_fatjet_id*/      printf("branch Common_fatjet_id_branch does not exist!\n");
+/*                        Common_fatjet_id*/      exit(1);
+/*                        Common_fatjet_id*/    }
+/*                        Common_fatjet_id*/    Common_fatjet_id_isLoaded = true;
+/*                        Common_fatjet_id*/  }
+/*                        Common_fatjet_id*/  return *Common_fatjet_id_;
+/*                        Common_fatjet_id*/}
 
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_msoftdrop*/const vector<float> &VVVTree::Common_fatjet_msoftdrop() {
@@ -1904,6 +3382,132 @@ void VVVTree::LoadAllBranches() {
 /*                 Common_fatjet_deepMD_bb*/  }
 /*                 Common_fatjet_deepMD_bb*/  return *Common_fatjet_deepMD_bb_;
 /*                 Common_fatjet_deepMD_bb*/}
+
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_particleNetMD_W*/const vector<float> &VVVTree::Common_fatjet_particleNetMD_W() {
+/*           Common_fatjet_particleNetMD_W*/  if (not Common_fatjet_particleNetMD_W_isLoaded) {
+/*           Common_fatjet_particleNetMD_W*/    if (Common_fatjet_particleNetMD_W_branch != 0) {
+/*           Common_fatjet_particleNetMD_W*/      Common_fatjet_particleNetMD_W_branch->GetEntry(index);
+/*           Common_fatjet_particleNetMD_W*/    } else {
+/*           Common_fatjet_particleNetMD_W*/      printf("branch Common_fatjet_particleNetMD_W_branch does not exist!\n");
+/*           Common_fatjet_particleNetMD_W*/      exit(1);
+/*           Common_fatjet_particleNetMD_W*/    }
+/*           Common_fatjet_particleNetMD_W*/    Common_fatjet_particleNetMD_W_isLoaded = true;
+/*           Common_fatjet_particleNetMD_W*/  }
+/*           Common_fatjet_particleNetMD_W*/  return *Common_fatjet_particleNetMD_W_;
+/*           Common_fatjet_particleNetMD_W*/}
+
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xqq*/const vector<float> &VVVTree::Common_fatjet_particleNetMD_Xqq() {
+/*         Common_fatjet_particleNetMD_Xqq*/  if (not Common_fatjet_particleNetMD_Xqq_isLoaded) {
+/*         Common_fatjet_particleNetMD_Xqq*/    if (Common_fatjet_particleNetMD_Xqq_branch != 0) {
+/*         Common_fatjet_particleNetMD_Xqq*/      Common_fatjet_particleNetMD_Xqq_branch->GetEntry(index);
+/*         Common_fatjet_particleNetMD_Xqq*/    } else {
+/*         Common_fatjet_particleNetMD_Xqq*/      printf("branch Common_fatjet_particleNetMD_Xqq_branch does not exist!\n");
+/*         Common_fatjet_particleNetMD_Xqq*/      exit(1);
+/*         Common_fatjet_particleNetMD_Xqq*/    }
+/*         Common_fatjet_particleNetMD_Xqq*/    Common_fatjet_particleNetMD_Xqq_isLoaded = true;
+/*         Common_fatjet_particleNetMD_Xqq*/  }
+/*         Common_fatjet_particleNetMD_Xqq*/  return *Common_fatjet_particleNetMD_Xqq_;
+/*         Common_fatjet_particleNetMD_Xqq*/}
+
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xcc*/const vector<float> &VVVTree::Common_fatjet_particleNetMD_Xcc() {
+/*         Common_fatjet_particleNetMD_Xcc*/  if (not Common_fatjet_particleNetMD_Xcc_isLoaded) {
+/*         Common_fatjet_particleNetMD_Xcc*/    if (Common_fatjet_particleNetMD_Xcc_branch != 0) {
+/*         Common_fatjet_particleNetMD_Xcc*/      Common_fatjet_particleNetMD_Xcc_branch->GetEntry(index);
+/*         Common_fatjet_particleNetMD_Xcc*/    } else {
+/*         Common_fatjet_particleNetMD_Xcc*/      printf("branch Common_fatjet_particleNetMD_Xcc_branch does not exist!\n");
+/*         Common_fatjet_particleNetMD_Xcc*/      exit(1);
+/*         Common_fatjet_particleNetMD_Xcc*/    }
+/*         Common_fatjet_particleNetMD_Xcc*/    Common_fatjet_particleNetMD_Xcc_isLoaded = true;
+/*         Common_fatjet_particleNetMD_Xcc*/  }
+/*         Common_fatjet_particleNetMD_Xcc*/  return *Common_fatjet_particleNetMD_Xcc_;
+/*         Common_fatjet_particleNetMD_Xcc*/}
+
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xbb*/const vector<float> &VVVTree::Common_fatjet_particleNetMD_Xbb() {
+/*         Common_fatjet_particleNetMD_Xbb*/  if (not Common_fatjet_particleNetMD_Xbb_isLoaded) {
+/*         Common_fatjet_particleNetMD_Xbb*/    if (Common_fatjet_particleNetMD_Xbb_branch != 0) {
+/*         Common_fatjet_particleNetMD_Xbb*/      Common_fatjet_particleNetMD_Xbb_branch->GetEntry(index);
+/*         Common_fatjet_particleNetMD_Xbb*/    } else {
+/*         Common_fatjet_particleNetMD_Xbb*/      printf("branch Common_fatjet_particleNetMD_Xbb_branch does not exist!\n");
+/*         Common_fatjet_particleNetMD_Xbb*/      exit(1);
+/*         Common_fatjet_particleNetMD_Xbb*/    }
+/*         Common_fatjet_particleNetMD_Xbb*/    Common_fatjet_particleNetMD_Xbb_isLoaded = true;
+/*         Common_fatjet_particleNetMD_Xbb*/  }
+/*         Common_fatjet_particleNetMD_Xbb*/  return *Common_fatjet_particleNetMD_Xbb_;
+/*         Common_fatjet_particleNetMD_Xbb*/}
+
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_QCD*/const vector<float> &VVVTree::Common_fatjet_particleNetMD_QCD() {
+/*         Common_fatjet_particleNetMD_QCD*/  if (not Common_fatjet_particleNetMD_QCD_isLoaded) {
+/*         Common_fatjet_particleNetMD_QCD*/    if (Common_fatjet_particleNetMD_QCD_branch != 0) {
+/*         Common_fatjet_particleNetMD_QCD*/      Common_fatjet_particleNetMD_QCD_branch->GetEntry(index);
+/*         Common_fatjet_particleNetMD_QCD*/    } else {
+/*         Common_fatjet_particleNetMD_QCD*/      printf("branch Common_fatjet_particleNetMD_QCD_branch does not exist!\n");
+/*         Common_fatjet_particleNetMD_QCD*/      exit(1);
+/*         Common_fatjet_particleNetMD_QCD*/    }
+/*         Common_fatjet_particleNetMD_QCD*/    Common_fatjet_particleNetMD_QCD_isLoaded = true;
+/*         Common_fatjet_particleNetMD_QCD*/  }
+/*         Common_fatjet_particleNetMD_QCD*/  return *Common_fatjet_particleNetMD_QCD_;
+/*         Common_fatjet_particleNetMD_QCD*/}
+
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_particleNet_QCD*/const vector<float> &VVVTree::Common_fatjet_particleNet_QCD() {
+/*           Common_fatjet_particleNet_QCD*/  if (not Common_fatjet_particleNet_QCD_isLoaded) {
+/*           Common_fatjet_particleNet_QCD*/    if (Common_fatjet_particleNet_QCD_branch != 0) {
+/*           Common_fatjet_particleNet_QCD*/      Common_fatjet_particleNet_QCD_branch->GetEntry(index);
+/*           Common_fatjet_particleNet_QCD*/    } else {
+/*           Common_fatjet_particleNet_QCD*/      printf("branch Common_fatjet_particleNet_QCD_branch does not exist!\n");
+/*           Common_fatjet_particleNet_QCD*/      exit(1);
+/*           Common_fatjet_particleNet_QCD*/    }
+/*           Common_fatjet_particleNet_QCD*/    Common_fatjet_particleNet_QCD_isLoaded = true;
+/*           Common_fatjet_particleNet_QCD*/  }
+/*           Common_fatjet_particleNet_QCD*/  return *Common_fatjet_particleNet_QCD_;
+/*           Common_fatjet_particleNet_QCD*/}
+
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_W*/const vector<float> &VVVTree::Common_fatjet_particleNet_W() {
+/*             Common_fatjet_particleNet_W*/  if (not Common_fatjet_particleNet_W_isLoaded) {
+/*             Common_fatjet_particleNet_W*/    if (Common_fatjet_particleNet_W_branch != 0) {
+/*             Common_fatjet_particleNet_W*/      Common_fatjet_particleNet_W_branch->GetEntry(index);
+/*             Common_fatjet_particleNet_W*/    } else {
+/*             Common_fatjet_particleNet_W*/      printf("branch Common_fatjet_particleNet_W_branch does not exist!\n");
+/*             Common_fatjet_particleNet_W*/      exit(1);
+/*             Common_fatjet_particleNet_W*/    }
+/*             Common_fatjet_particleNet_W*/    Common_fatjet_particleNet_W_isLoaded = true;
+/*             Common_fatjet_particleNet_W*/  }
+/*             Common_fatjet_particleNet_W*/  return *Common_fatjet_particleNet_W_;
+/*             Common_fatjet_particleNet_W*/}
+
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_Z*/const vector<float> &VVVTree::Common_fatjet_particleNet_Z() {
+/*             Common_fatjet_particleNet_Z*/  if (not Common_fatjet_particleNet_Z_isLoaded) {
+/*             Common_fatjet_particleNet_Z*/    if (Common_fatjet_particleNet_Z_branch != 0) {
+/*             Common_fatjet_particleNet_Z*/      Common_fatjet_particleNet_Z_branch->GetEntry(index);
+/*             Common_fatjet_particleNet_Z*/    } else {
+/*             Common_fatjet_particleNet_Z*/      printf("branch Common_fatjet_particleNet_Z_branch does not exist!\n");
+/*             Common_fatjet_particleNet_Z*/      exit(1);
+/*             Common_fatjet_particleNet_Z*/    }
+/*             Common_fatjet_particleNet_Z*/    Common_fatjet_particleNet_Z_isLoaded = true;
+/*             Common_fatjet_particleNet_Z*/  }
+/*             Common_fatjet_particleNet_Z*/  return *Common_fatjet_particleNet_Z_;
+/*             Common_fatjet_particleNet_Z*/}
+
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_T*/const vector<float> &VVVTree::Common_fatjet_particleNet_T() {
+/*             Common_fatjet_particleNet_T*/  if (not Common_fatjet_particleNet_T_isLoaded) {
+/*             Common_fatjet_particleNet_T*/    if (Common_fatjet_particleNet_T_branch != 0) {
+/*             Common_fatjet_particleNet_T*/      Common_fatjet_particleNet_T_branch->GetEntry(index);
+/*             Common_fatjet_particleNet_T*/    } else {
+/*             Common_fatjet_particleNet_T*/      printf("branch Common_fatjet_particleNet_T_branch does not exist!\n");
+/*             Common_fatjet_particleNet_T*/      exit(1);
+/*             Common_fatjet_particleNet_T*/    }
+/*             Common_fatjet_particleNet_T*/    Common_fatjet_particleNet_T_isLoaded = true;
+/*             Common_fatjet_particleNet_T*/  }
+/*             Common_fatjet_particleNet_T*/  return *Common_fatjet_particleNet_T_;
+/*             Common_fatjet_particleNet_T*/}
 
 //---------------------------------------------------------------------------------
 /*                      Common_fatjet_tau3*/const vector<float> &VVVTree::Common_fatjet_tau3() {
@@ -2130,6 +3734,20 @@ void VVVTree::LoadAllBranches() {
 /*                        Common_fatjet_WP*/}
 
 //---------------------------------------------------------------------------------
+/*                     Common_fatjet_WP_MD*/const vector<int> &VVVTree::Common_fatjet_WP_MD() {
+/*                     Common_fatjet_WP_MD*/  if (not Common_fatjet_WP_MD_isLoaded) {
+/*                     Common_fatjet_WP_MD*/    if (Common_fatjet_WP_MD_branch != 0) {
+/*                     Common_fatjet_WP_MD*/      Common_fatjet_WP_MD_branch->GetEntry(index);
+/*                     Common_fatjet_WP_MD*/    } else {
+/*                     Common_fatjet_WP_MD*/      printf("branch Common_fatjet_WP_MD_branch does not exist!\n");
+/*                     Common_fatjet_WP_MD*/      exit(1);
+/*                     Common_fatjet_WP_MD*/    }
+/*                     Common_fatjet_WP_MD*/    Common_fatjet_WP_MD_isLoaded = true;
+/*                     Common_fatjet_WP_MD*/  }
+/*                     Common_fatjet_WP_MD*/  return *Common_fatjet_WP_MD_;
+/*                     Common_fatjet_WP_MD*/}
+
+//---------------------------------------------------------------------------------
 /*            Common_fatjet_WP_antimasscut*/const vector<int> &VVVTree::Common_fatjet_WP_antimasscut() {
 /*            Common_fatjet_WP_antimasscut*/  if (not Common_fatjet_WP_antimasscut_isLoaded) {
 /*            Common_fatjet_WP_antimasscut*/    if (Common_fatjet_WP_antimasscut_branch != 0) {
@@ -2310,6 +3928,286 @@ void VVVTree::LoadAllBranches() {
 /*                 Common_fatjet_SFupTight*/  }
 /*                 Common_fatjet_SFupTight*/  return *Common_fatjet_SFupTight_;
 /*                 Common_fatjet_SFupTight*/}
+
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jesup*/const vector<float> &VVVTree::Common_fatjet_pt_jesup() {
+/*                  Common_fatjet_pt_jesup*/  if (not Common_fatjet_pt_jesup_isLoaded) {
+/*                  Common_fatjet_pt_jesup*/    if (Common_fatjet_pt_jesup_branch != 0) {
+/*                  Common_fatjet_pt_jesup*/      Common_fatjet_pt_jesup_branch->GetEntry(index);
+/*                  Common_fatjet_pt_jesup*/    } else {
+/*                  Common_fatjet_pt_jesup*/      printf("branch Common_fatjet_pt_jesup_branch does not exist!\n");
+/*                  Common_fatjet_pt_jesup*/      exit(1);
+/*                  Common_fatjet_pt_jesup*/    }
+/*                  Common_fatjet_pt_jesup*/    Common_fatjet_pt_jesup_isLoaded = true;
+/*                  Common_fatjet_pt_jesup*/  }
+/*                  Common_fatjet_pt_jesup*/  return *Common_fatjet_pt_jesup_;
+/*                  Common_fatjet_pt_jesup*/}
+
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jesdn*/const vector<float> &VVVTree::Common_fatjet_pt_jesdn() {
+/*                  Common_fatjet_pt_jesdn*/  if (not Common_fatjet_pt_jesdn_isLoaded) {
+/*                  Common_fatjet_pt_jesdn*/    if (Common_fatjet_pt_jesdn_branch != 0) {
+/*                  Common_fatjet_pt_jesdn*/      Common_fatjet_pt_jesdn_branch->GetEntry(index);
+/*                  Common_fatjet_pt_jesdn*/    } else {
+/*                  Common_fatjet_pt_jesdn*/      printf("branch Common_fatjet_pt_jesdn_branch does not exist!\n");
+/*                  Common_fatjet_pt_jesdn*/      exit(1);
+/*                  Common_fatjet_pt_jesdn*/    }
+/*                  Common_fatjet_pt_jesdn*/    Common_fatjet_pt_jesdn_isLoaded = true;
+/*                  Common_fatjet_pt_jesdn*/  }
+/*                  Common_fatjet_pt_jesdn*/  return *Common_fatjet_pt_jesdn_;
+/*                  Common_fatjet_pt_jesdn*/}
+
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jerup*/const vector<float> &VVVTree::Common_fatjet_pt_jerup() {
+/*                  Common_fatjet_pt_jerup*/  if (not Common_fatjet_pt_jerup_isLoaded) {
+/*                  Common_fatjet_pt_jerup*/    if (Common_fatjet_pt_jerup_branch != 0) {
+/*                  Common_fatjet_pt_jerup*/      Common_fatjet_pt_jerup_branch->GetEntry(index);
+/*                  Common_fatjet_pt_jerup*/    } else {
+/*                  Common_fatjet_pt_jerup*/      printf("branch Common_fatjet_pt_jerup_branch does not exist!\n");
+/*                  Common_fatjet_pt_jerup*/      exit(1);
+/*                  Common_fatjet_pt_jerup*/    }
+/*                  Common_fatjet_pt_jerup*/    Common_fatjet_pt_jerup_isLoaded = true;
+/*                  Common_fatjet_pt_jerup*/  }
+/*                  Common_fatjet_pt_jerup*/  return *Common_fatjet_pt_jerup_;
+/*                  Common_fatjet_pt_jerup*/}
+
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jerdn*/const vector<float> &VVVTree::Common_fatjet_pt_jerdn() {
+/*                  Common_fatjet_pt_jerdn*/  if (not Common_fatjet_pt_jerdn_isLoaded) {
+/*                  Common_fatjet_pt_jerdn*/    if (Common_fatjet_pt_jerdn_branch != 0) {
+/*                  Common_fatjet_pt_jerdn*/      Common_fatjet_pt_jerdn_branch->GetEntry(index);
+/*                  Common_fatjet_pt_jerdn*/    } else {
+/*                  Common_fatjet_pt_jerdn*/      printf("branch Common_fatjet_pt_jerdn_branch does not exist!\n");
+/*                  Common_fatjet_pt_jerdn*/      exit(1);
+/*                  Common_fatjet_pt_jerdn*/    }
+/*                  Common_fatjet_pt_jerdn*/    Common_fatjet_pt_jerdn_isLoaded = true;
+/*                  Common_fatjet_pt_jerdn*/  }
+/*                  Common_fatjet_pt_jerdn*/  return *Common_fatjet_pt_jerdn_;
+/*                  Common_fatjet_pt_jerdn*/}
+
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jesup*/const vector<float> &VVVTree::Common_fatjet_msoftdrop_jesup() {
+/*           Common_fatjet_msoftdrop_jesup*/  if (not Common_fatjet_msoftdrop_jesup_isLoaded) {
+/*           Common_fatjet_msoftdrop_jesup*/    if (Common_fatjet_msoftdrop_jesup_branch != 0) {
+/*           Common_fatjet_msoftdrop_jesup*/      Common_fatjet_msoftdrop_jesup_branch->GetEntry(index);
+/*           Common_fatjet_msoftdrop_jesup*/    } else {
+/*           Common_fatjet_msoftdrop_jesup*/      printf("branch Common_fatjet_msoftdrop_jesup_branch does not exist!\n");
+/*           Common_fatjet_msoftdrop_jesup*/      exit(1);
+/*           Common_fatjet_msoftdrop_jesup*/    }
+/*           Common_fatjet_msoftdrop_jesup*/    Common_fatjet_msoftdrop_jesup_isLoaded = true;
+/*           Common_fatjet_msoftdrop_jesup*/  }
+/*           Common_fatjet_msoftdrop_jesup*/  return *Common_fatjet_msoftdrop_jesup_;
+/*           Common_fatjet_msoftdrop_jesup*/}
+
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jesdn*/const vector<float> &VVVTree::Common_fatjet_msoftdrop_jesdn() {
+/*           Common_fatjet_msoftdrop_jesdn*/  if (not Common_fatjet_msoftdrop_jesdn_isLoaded) {
+/*           Common_fatjet_msoftdrop_jesdn*/    if (Common_fatjet_msoftdrop_jesdn_branch != 0) {
+/*           Common_fatjet_msoftdrop_jesdn*/      Common_fatjet_msoftdrop_jesdn_branch->GetEntry(index);
+/*           Common_fatjet_msoftdrop_jesdn*/    } else {
+/*           Common_fatjet_msoftdrop_jesdn*/      printf("branch Common_fatjet_msoftdrop_jesdn_branch does not exist!\n");
+/*           Common_fatjet_msoftdrop_jesdn*/      exit(1);
+/*           Common_fatjet_msoftdrop_jesdn*/    }
+/*           Common_fatjet_msoftdrop_jesdn*/    Common_fatjet_msoftdrop_jesdn_isLoaded = true;
+/*           Common_fatjet_msoftdrop_jesdn*/  }
+/*           Common_fatjet_msoftdrop_jesdn*/  return *Common_fatjet_msoftdrop_jesdn_;
+/*           Common_fatjet_msoftdrop_jesdn*/}
+
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jerup*/const vector<float> &VVVTree::Common_fatjet_msoftdrop_jerup() {
+/*           Common_fatjet_msoftdrop_jerup*/  if (not Common_fatjet_msoftdrop_jerup_isLoaded) {
+/*           Common_fatjet_msoftdrop_jerup*/    if (Common_fatjet_msoftdrop_jerup_branch != 0) {
+/*           Common_fatjet_msoftdrop_jerup*/      Common_fatjet_msoftdrop_jerup_branch->GetEntry(index);
+/*           Common_fatjet_msoftdrop_jerup*/    } else {
+/*           Common_fatjet_msoftdrop_jerup*/      printf("branch Common_fatjet_msoftdrop_jerup_branch does not exist!\n");
+/*           Common_fatjet_msoftdrop_jerup*/      exit(1);
+/*           Common_fatjet_msoftdrop_jerup*/    }
+/*           Common_fatjet_msoftdrop_jerup*/    Common_fatjet_msoftdrop_jerup_isLoaded = true;
+/*           Common_fatjet_msoftdrop_jerup*/  }
+/*           Common_fatjet_msoftdrop_jerup*/  return *Common_fatjet_msoftdrop_jerup_;
+/*           Common_fatjet_msoftdrop_jerup*/}
+
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jerdn*/const vector<float> &VVVTree::Common_fatjet_msoftdrop_jerdn() {
+/*           Common_fatjet_msoftdrop_jerdn*/  if (not Common_fatjet_msoftdrop_jerdn_isLoaded) {
+/*           Common_fatjet_msoftdrop_jerdn*/    if (Common_fatjet_msoftdrop_jerdn_branch != 0) {
+/*           Common_fatjet_msoftdrop_jerdn*/      Common_fatjet_msoftdrop_jerdn_branch->GetEntry(index);
+/*           Common_fatjet_msoftdrop_jerdn*/    } else {
+/*           Common_fatjet_msoftdrop_jerdn*/      printf("branch Common_fatjet_msoftdrop_jerdn_branch does not exist!\n");
+/*           Common_fatjet_msoftdrop_jerdn*/      exit(1);
+/*           Common_fatjet_msoftdrop_jerdn*/    }
+/*           Common_fatjet_msoftdrop_jerdn*/    Common_fatjet_msoftdrop_jerdn_isLoaded = true;
+/*           Common_fatjet_msoftdrop_jerdn*/  }
+/*           Common_fatjet_msoftdrop_jerdn*/  return *Common_fatjet_msoftdrop_jerdn_;
+/*           Common_fatjet_msoftdrop_jerdn*/}
+
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmsup*/const vector<float> &VVVTree::Common_fatjet_msoftdrop_jmsup() {
+/*           Common_fatjet_msoftdrop_jmsup*/  if (not Common_fatjet_msoftdrop_jmsup_isLoaded) {
+/*           Common_fatjet_msoftdrop_jmsup*/    if (Common_fatjet_msoftdrop_jmsup_branch != 0) {
+/*           Common_fatjet_msoftdrop_jmsup*/      Common_fatjet_msoftdrop_jmsup_branch->GetEntry(index);
+/*           Common_fatjet_msoftdrop_jmsup*/    } else {
+/*           Common_fatjet_msoftdrop_jmsup*/      printf("branch Common_fatjet_msoftdrop_jmsup_branch does not exist!\n");
+/*           Common_fatjet_msoftdrop_jmsup*/      exit(1);
+/*           Common_fatjet_msoftdrop_jmsup*/    }
+/*           Common_fatjet_msoftdrop_jmsup*/    Common_fatjet_msoftdrop_jmsup_isLoaded = true;
+/*           Common_fatjet_msoftdrop_jmsup*/  }
+/*           Common_fatjet_msoftdrop_jmsup*/  return *Common_fatjet_msoftdrop_jmsup_;
+/*           Common_fatjet_msoftdrop_jmsup*/}
+
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmsdn*/const vector<float> &VVVTree::Common_fatjet_msoftdrop_jmsdn() {
+/*           Common_fatjet_msoftdrop_jmsdn*/  if (not Common_fatjet_msoftdrop_jmsdn_isLoaded) {
+/*           Common_fatjet_msoftdrop_jmsdn*/    if (Common_fatjet_msoftdrop_jmsdn_branch != 0) {
+/*           Common_fatjet_msoftdrop_jmsdn*/      Common_fatjet_msoftdrop_jmsdn_branch->GetEntry(index);
+/*           Common_fatjet_msoftdrop_jmsdn*/    } else {
+/*           Common_fatjet_msoftdrop_jmsdn*/      printf("branch Common_fatjet_msoftdrop_jmsdn_branch does not exist!\n");
+/*           Common_fatjet_msoftdrop_jmsdn*/      exit(1);
+/*           Common_fatjet_msoftdrop_jmsdn*/    }
+/*           Common_fatjet_msoftdrop_jmsdn*/    Common_fatjet_msoftdrop_jmsdn_isLoaded = true;
+/*           Common_fatjet_msoftdrop_jmsdn*/  }
+/*           Common_fatjet_msoftdrop_jmsdn*/  return *Common_fatjet_msoftdrop_jmsdn_;
+/*           Common_fatjet_msoftdrop_jmsdn*/}
+
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmrup*/const vector<float> &VVVTree::Common_fatjet_msoftdrop_jmrup() {
+/*           Common_fatjet_msoftdrop_jmrup*/  if (not Common_fatjet_msoftdrop_jmrup_isLoaded) {
+/*           Common_fatjet_msoftdrop_jmrup*/    if (Common_fatjet_msoftdrop_jmrup_branch != 0) {
+/*           Common_fatjet_msoftdrop_jmrup*/      Common_fatjet_msoftdrop_jmrup_branch->GetEntry(index);
+/*           Common_fatjet_msoftdrop_jmrup*/    } else {
+/*           Common_fatjet_msoftdrop_jmrup*/      printf("branch Common_fatjet_msoftdrop_jmrup_branch does not exist!\n");
+/*           Common_fatjet_msoftdrop_jmrup*/      exit(1);
+/*           Common_fatjet_msoftdrop_jmrup*/    }
+/*           Common_fatjet_msoftdrop_jmrup*/    Common_fatjet_msoftdrop_jmrup_isLoaded = true;
+/*           Common_fatjet_msoftdrop_jmrup*/  }
+/*           Common_fatjet_msoftdrop_jmrup*/  return *Common_fatjet_msoftdrop_jmrup_;
+/*           Common_fatjet_msoftdrop_jmrup*/}
+
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmrdn*/const vector<float> &VVVTree::Common_fatjet_msoftdrop_jmrdn() {
+/*           Common_fatjet_msoftdrop_jmrdn*/  if (not Common_fatjet_msoftdrop_jmrdn_isLoaded) {
+/*           Common_fatjet_msoftdrop_jmrdn*/    if (Common_fatjet_msoftdrop_jmrdn_branch != 0) {
+/*           Common_fatjet_msoftdrop_jmrdn*/      Common_fatjet_msoftdrop_jmrdn_branch->GetEntry(index);
+/*           Common_fatjet_msoftdrop_jmrdn*/    } else {
+/*           Common_fatjet_msoftdrop_jmrdn*/      printf("branch Common_fatjet_msoftdrop_jmrdn_branch does not exist!\n");
+/*           Common_fatjet_msoftdrop_jmrdn*/      exit(1);
+/*           Common_fatjet_msoftdrop_jmrdn*/    }
+/*           Common_fatjet_msoftdrop_jmrdn*/    Common_fatjet_msoftdrop_jmrdn_isLoaded = true;
+/*           Common_fatjet_msoftdrop_jmrdn*/  }
+/*           Common_fatjet_msoftdrop_jmrdn*/  return *Common_fatjet_msoftdrop_jmrdn_;
+/*           Common_fatjet_msoftdrop_jmrdn*/}
+
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jesup*/const vector<float> &VVVTree::Common_fatjet_mass_jesup() {
+/*                Common_fatjet_mass_jesup*/  if (not Common_fatjet_mass_jesup_isLoaded) {
+/*                Common_fatjet_mass_jesup*/    if (Common_fatjet_mass_jesup_branch != 0) {
+/*                Common_fatjet_mass_jesup*/      Common_fatjet_mass_jesup_branch->GetEntry(index);
+/*                Common_fatjet_mass_jesup*/    } else {
+/*                Common_fatjet_mass_jesup*/      printf("branch Common_fatjet_mass_jesup_branch does not exist!\n");
+/*                Common_fatjet_mass_jesup*/      exit(1);
+/*                Common_fatjet_mass_jesup*/    }
+/*                Common_fatjet_mass_jesup*/    Common_fatjet_mass_jesup_isLoaded = true;
+/*                Common_fatjet_mass_jesup*/  }
+/*                Common_fatjet_mass_jesup*/  return *Common_fatjet_mass_jesup_;
+/*                Common_fatjet_mass_jesup*/}
+
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jesdn*/const vector<float> &VVVTree::Common_fatjet_mass_jesdn() {
+/*                Common_fatjet_mass_jesdn*/  if (not Common_fatjet_mass_jesdn_isLoaded) {
+/*                Common_fatjet_mass_jesdn*/    if (Common_fatjet_mass_jesdn_branch != 0) {
+/*                Common_fatjet_mass_jesdn*/      Common_fatjet_mass_jesdn_branch->GetEntry(index);
+/*                Common_fatjet_mass_jesdn*/    } else {
+/*                Common_fatjet_mass_jesdn*/      printf("branch Common_fatjet_mass_jesdn_branch does not exist!\n");
+/*                Common_fatjet_mass_jesdn*/      exit(1);
+/*                Common_fatjet_mass_jesdn*/    }
+/*                Common_fatjet_mass_jesdn*/    Common_fatjet_mass_jesdn_isLoaded = true;
+/*                Common_fatjet_mass_jesdn*/  }
+/*                Common_fatjet_mass_jesdn*/  return *Common_fatjet_mass_jesdn_;
+/*                Common_fatjet_mass_jesdn*/}
+
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jerup*/const vector<float> &VVVTree::Common_fatjet_mass_jerup() {
+/*                Common_fatjet_mass_jerup*/  if (not Common_fatjet_mass_jerup_isLoaded) {
+/*                Common_fatjet_mass_jerup*/    if (Common_fatjet_mass_jerup_branch != 0) {
+/*                Common_fatjet_mass_jerup*/      Common_fatjet_mass_jerup_branch->GetEntry(index);
+/*                Common_fatjet_mass_jerup*/    } else {
+/*                Common_fatjet_mass_jerup*/      printf("branch Common_fatjet_mass_jerup_branch does not exist!\n");
+/*                Common_fatjet_mass_jerup*/      exit(1);
+/*                Common_fatjet_mass_jerup*/    }
+/*                Common_fatjet_mass_jerup*/    Common_fatjet_mass_jerup_isLoaded = true;
+/*                Common_fatjet_mass_jerup*/  }
+/*                Common_fatjet_mass_jerup*/  return *Common_fatjet_mass_jerup_;
+/*                Common_fatjet_mass_jerup*/}
+
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jerdn*/const vector<float> &VVVTree::Common_fatjet_mass_jerdn() {
+/*                Common_fatjet_mass_jerdn*/  if (not Common_fatjet_mass_jerdn_isLoaded) {
+/*                Common_fatjet_mass_jerdn*/    if (Common_fatjet_mass_jerdn_branch != 0) {
+/*                Common_fatjet_mass_jerdn*/      Common_fatjet_mass_jerdn_branch->GetEntry(index);
+/*                Common_fatjet_mass_jerdn*/    } else {
+/*                Common_fatjet_mass_jerdn*/      printf("branch Common_fatjet_mass_jerdn_branch does not exist!\n");
+/*                Common_fatjet_mass_jerdn*/      exit(1);
+/*                Common_fatjet_mass_jerdn*/    }
+/*                Common_fatjet_mass_jerdn*/    Common_fatjet_mass_jerdn_isLoaded = true;
+/*                Common_fatjet_mass_jerdn*/  }
+/*                Common_fatjet_mass_jerdn*/  return *Common_fatjet_mass_jerdn_;
+/*                Common_fatjet_mass_jerdn*/}
+
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmsup*/const vector<float> &VVVTree::Common_fatjet_mass_jmsup() {
+/*                Common_fatjet_mass_jmsup*/  if (not Common_fatjet_mass_jmsup_isLoaded) {
+/*                Common_fatjet_mass_jmsup*/    if (Common_fatjet_mass_jmsup_branch != 0) {
+/*                Common_fatjet_mass_jmsup*/      Common_fatjet_mass_jmsup_branch->GetEntry(index);
+/*                Common_fatjet_mass_jmsup*/    } else {
+/*                Common_fatjet_mass_jmsup*/      printf("branch Common_fatjet_mass_jmsup_branch does not exist!\n");
+/*                Common_fatjet_mass_jmsup*/      exit(1);
+/*                Common_fatjet_mass_jmsup*/    }
+/*                Common_fatjet_mass_jmsup*/    Common_fatjet_mass_jmsup_isLoaded = true;
+/*                Common_fatjet_mass_jmsup*/  }
+/*                Common_fatjet_mass_jmsup*/  return *Common_fatjet_mass_jmsup_;
+/*                Common_fatjet_mass_jmsup*/}
+
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmsdn*/const vector<float> &VVVTree::Common_fatjet_mass_jmsdn() {
+/*                Common_fatjet_mass_jmsdn*/  if (not Common_fatjet_mass_jmsdn_isLoaded) {
+/*                Common_fatjet_mass_jmsdn*/    if (Common_fatjet_mass_jmsdn_branch != 0) {
+/*                Common_fatjet_mass_jmsdn*/      Common_fatjet_mass_jmsdn_branch->GetEntry(index);
+/*                Common_fatjet_mass_jmsdn*/    } else {
+/*                Common_fatjet_mass_jmsdn*/      printf("branch Common_fatjet_mass_jmsdn_branch does not exist!\n");
+/*                Common_fatjet_mass_jmsdn*/      exit(1);
+/*                Common_fatjet_mass_jmsdn*/    }
+/*                Common_fatjet_mass_jmsdn*/    Common_fatjet_mass_jmsdn_isLoaded = true;
+/*                Common_fatjet_mass_jmsdn*/  }
+/*                Common_fatjet_mass_jmsdn*/  return *Common_fatjet_mass_jmsdn_;
+/*                Common_fatjet_mass_jmsdn*/}
+
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmrup*/const vector<float> &VVVTree::Common_fatjet_mass_jmrup() {
+/*                Common_fatjet_mass_jmrup*/  if (not Common_fatjet_mass_jmrup_isLoaded) {
+/*                Common_fatjet_mass_jmrup*/    if (Common_fatjet_mass_jmrup_branch != 0) {
+/*                Common_fatjet_mass_jmrup*/      Common_fatjet_mass_jmrup_branch->GetEntry(index);
+/*                Common_fatjet_mass_jmrup*/    } else {
+/*                Common_fatjet_mass_jmrup*/      printf("branch Common_fatjet_mass_jmrup_branch does not exist!\n");
+/*                Common_fatjet_mass_jmrup*/      exit(1);
+/*                Common_fatjet_mass_jmrup*/    }
+/*                Common_fatjet_mass_jmrup*/    Common_fatjet_mass_jmrup_isLoaded = true;
+/*                Common_fatjet_mass_jmrup*/  }
+/*                Common_fatjet_mass_jmrup*/  return *Common_fatjet_mass_jmrup_;
+/*                Common_fatjet_mass_jmrup*/}
+
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmrdn*/const vector<float> &VVVTree::Common_fatjet_mass_jmrdn() {
+/*                Common_fatjet_mass_jmrdn*/  if (not Common_fatjet_mass_jmrdn_isLoaded) {
+/*                Common_fatjet_mass_jmrdn*/    if (Common_fatjet_mass_jmrdn_branch != 0) {
+/*                Common_fatjet_mass_jmrdn*/      Common_fatjet_mass_jmrdn_branch->GetEntry(index);
+/*                Common_fatjet_mass_jmrdn*/    } else {
+/*                Common_fatjet_mass_jmrdn*/      printf("branch Common_fatjet_mass_jmrdn_branch does not exist!\n");
+/*                Common_fatjet_mass_jmrdn*/      exit(1);
+/*                Common_fatjet_mass_jmrdn*/    }
+/*                Common_fatjet_mass_jmrdn*/    Common_fatjet_mass_jmrdn_isLoaded = true;
+/*                Common_fatjet_mass_jmrdn*/  }
+/*                Common_fatjet_mass_jmrdn*/  return *Common_fatjet_mass_jmrdn_;
+/*                Common_fatjet_mass_jmrdn*/}
 
 //---------------------------------------------------------------------------------
 /*      Common_eventweight_fatjet_SFVLoose*/const float &VVVTree::Common_eventweight_fatjet_SFVLoose() {
@@ -2674,6 +4572,20 @@ void VVVTree::LoadAllBranches() {
 /*          Common_gen_vvvdecay_taudecayid*/  }
 /*          Common_gen_vvvdecay_taudecayid*/  return *Common_gen_vvvdecay_taudecayid_;
 /*          Common_gen_vvvdecay_taudecayid*/}
+
+//---------------------------------------------------------------------------------
+/*                         Common_isSignal*/const bool &VVVTree::Common_isSignal() {
+/*                         Common_isSignal*/  if (not Common_isSignal_isLoaded) {
+/*                         Common_isSignal*/    if (Common_isSignal_branch != 0) {
+/*                         Common_isSignal*/      Common_isSignal_branch->GetEntry(index);
+/*                         Common_isSignal*/    } else {
+/*                         Common_isSignal*/      printf("branch Common_isSignal_branch does not exist!\n");
+/*                         Common_isSignal*/      exit(1);
+/*                         Common_isSignal*/    }
+/*                         Common_isSignal*/    Common_isSignal_isLoaded = true;
+/*                         Common_isSignal*/  }
+/*                         Common_isSignal*/  return Common_isSignal_;
+/*                         Common_isSignal*/}
 
 //---------------------------------------------------------------------------------
 /*                              Common_n_W*/const int &VVVTree::Common_n_W() {
@@ -3188,6 +5100,26 @@ namespace tas {
 //---------------------------------------------------------------------------------
 /*              Common_btagWeight_DeepCSVB*/const float &Common_btagWeight_DeepCSVB() { return vvv.Common_btagWeight_DeepCSVB(); }
 //---------------------------------------------------------------------------------
+/*                              Common_wgt*/const float &Common_wgt() { return vvv.Common_wgt(); }
+//---------------------------------------------------------------------------------
+/*                   Common_event_puWeight*/const float &Common_event_puWeight() { return vvv.Common_event_puWeight(); }
+//---------------------------------------------------------------------------------
+/*                 Common_event_puWeightup*/const float &Common_event_puWeightup() { return vvv.Common_event_puWeightup(); }
+//---------------------------------------------------------------------------------
+/*                 Common_event_puWeightdn*/const float &Common_event_puWeightdn() { return vvv.Common_event_puWeightdn(); }
+//---------------------------------------------------------------------------------
+/*              Common_event_prefireWeight*/const float &Common_event_prefireWeight() { return vvv.Common_event_prefireWeight(); }
+//---------------------------------------------------------------------------------
+/*            Common_event_prefireWeightup*/const float &Common_event_prefireWeightup() { return vvv.Common_event_prefireWeightup(); }
+//---------------------------------------------------------------------------------
+/*            Common_event_prefireWeightdn*/const float &Common_event_prefireWeightdn() { return vvv.Common_event_prefireWeightdn(); }
+//---------------------------------------------------------------------------------
+/*              Common_event_triggerWeight*/const float &Common_event_triggerWeight() { return vvv.Common_event_triggerWeight(); }
+//---------------------------------------------------------------------------------
+/*            Common_event_triggerWeightup*/const float &Common_event_triggerWeightup() { return vvv.Common_event_triggerWeightup(); }
+//---------------------------------------------------------------------------------
+/*            Common_event_triggerWeightdn*/const float &Common_event_triggerWeightdn() { return vvv.Common_event_triggerWeightdn(); }
+//---------------------------------------------------------------------------------
 /*         Common_LHEWeight_mg_reweighting*/const vector<float> &Common_LHEWeight_mg_reweighting() { return vvv.Common_LHEWeight_mg_reweighting(); }
 //---------------------------------------------------------------------------------
 /*Common_HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ*/const bool &Common_HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ() { return vvv.Common_HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ(); }
@@ -3208,6 +5140,26 @@ namespace tas {
 //---------------------------------------------------------------------------------
 /*Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL*/const bool &Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL() { return vvv.Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL(); }
 //---------------------------------------------------------------------------------
+/*                     Common_HLT_PFHT1050*/const bool &Common_HLT_PFHT1050() { return vvv.Common_HLT_PFHT1050(); }
+//---------------------------------------------------------------------------------
+/*                  Common_HLT_AK8PFJet500*/const bool &Common_HLT_AK8PFJet500() { return vvv.Common_HLT_AK8PFJet500(); }
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet380_TrimMass30*/const bool &Common_HLT_AK8PFJet380_TrimMass30() { return vvv.Common_HLT_AK8PFJet380_TrimMass30(); }
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet360_TrimMass30*/const bool &Common_HLT_AK8PFJet360_TrimMass30() { return vvv.Common_HLT_AK8PFJet360_TrimMass30(); }
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet400_TrimMass30*/const bool &Common_HLT_AK8PFJet400_TrimMass30() { return vvv.Common_HLT_AK8PFJet400_TrimMass30(); }
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet420_TrimMass30*/const bool &Common_HLT_AK8PFJet420_TrimMass30() { return vvv.Common_HLT_AK8PFJet420_TrimMass30(); }
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT750_TrimMass50*/const bool &Common_HLT_AK8PFHT750_TrimMass50() { return vvv.Common_HLT_AK8PFHT750_TrimMass50(); }
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT800_TrimMass50*/const bool &Common_HLT_AK8PFHT800_TrimMass50() { return vvv.Common_HLT_AK8PFHT800_TrimMass50(); }
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT850_TrimMass50*/const bool &Common_HLT_AK8PFHT850_TrimMass50() { return vvv.Common_HLT_AK8PFHT850_TrimMass50(); }
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT900_TrimMass50*/const bool &Common_HLT_AK8PFHT900_TrimMass50() { return vvv.Common_HLT_AK8PFHT900_TrimMass50(); }
+//---------------------------------------------------------------------------------
 /*                     Common_HLT_DoubleEl*/const bool &Common_HLT_DoubleEl() { return vvv.Common_HLT_DoubleEl(); }
 //---------------------------------------------------------------------------------
 /*                         Common_HLT_MuEG*/const bool &Common_HLT_MuEG() { return vvv.Common_HLT_MuEG(); }
@@ -3226,6 +5178,14 @@ namespace tas {
 //---------------------------------------------------------------------------------
 /*                           Common_met_p4*/const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &Common_met_p4() { return vvv.Common_met_p4(); }
 //---------------------------------------------------------------------------------
+/*                     Common_met_p4_jesup*/const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &Common_met_p4_jesup() { return vvv.Common_met_p4_jesup(); }
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jesdn*/const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &Common_met_p4_jesdn() { return vvv.Common_met_p4_jesdn(); }
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jerup*/const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &Common_met_p4_jerup() { return vvv.Common_met_p4_jerup(); }
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jerdn*/const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &Common_met_p4_jerdn() { return vvv.Common_met_p4_jerdn(); }
+//---------------------------------------------------------------------------------
 /*                      Common_event_lepSF*/const float &Common_event_lepSF() { return vvv.Common_event_lepSF(); }
 //---------------------------------------------------------------------------------
 /*                  Common_event_lepSFelup*/const float &Common_event_lepSFelup() { return vvv.Common_event_lepSFelup(); }
@@ -3235,6 +5195,58 @@ namespace tas {
 /*                  Common_event_lepSFmuup*/const float &Common_event_lepSFmuup() { return vvv.Common_event_lepSFmuup(); }
 //---------------------------------------------------------------------------------
 /*                  Common_event_lepSFmudn*/const float &Common_event_lepSFmudn() { return vvv.Common_event_lepSFmudn(); }
+//---------------------------------------------------------------------------------
+/*                 Common_event_lepSFTight*/const float &Common_event_lepSFTight() { return vvv.Common_event_lepSFTight(); }
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFelupTight*/const float &Common_event_lepSFelupTight() { return vvv.Common_event_lepSFelupTight(); }
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFeldnTight*/const float &Common_event_lepSFeldnTight() { return vvv.Common_event_lepSFeldnTight(); }
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFmuupTight*/const float &Common_event_lepSFmuupTight() { return vvv.Common_event_lepSFmuupTight(); }
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFmudnTight*/const float &Common_event_lepSFmudnTight() { return vvv.Common_event_lepSFmudnTight(); }
+//---------------------------------------------------------------------------------
+/*                Common_event_tightBtagSF*/const float &Common_event_tightBtagSF() { return vvv.Common_event_tightBtagSF(); }
+//---------------------------------------------------------------------------------
+/*              Common_event_tightBtagSFup*/const float &Common_event_tightBtagSFup() { return vvv.Common_event_tightBtagSFup(); }
+//---------------------------------------------------------------------------------
+/*              Common_event_tightBtagSFdn*/const float &Common_event_tightBtagSFdn() { return vvv.Common_event_tightBtagSFdn(); }
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFHFup*/const float &Common_event_tightBtagSFHFup() { return vvv.Common_event_tightBtagSFHFup(); }
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFHFdn*/const float &Common_event_tightBtagSFHFdn() { return vvv.Common_event_tightBtagSFHFdn(); }
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFLFup*/const float &Common_event_tightBtagSFLFup() { return vvv.Common_event_tightBtagSFLFup(); }
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFLFdn*/const float &Common_event_tightBtagSFLFdn() { return vvv.Common_event_tightBtagSFLFdn(); }
+//---------------------------------------------------------------------------------
+/*               Common_event_mediumBtagSF*/const float &Common_event_mediumBtagSF() { return vvv.Common_event_mediumBtagSF(); }
+//---------------------------------------------------------------------------------
+/*             Common_event_mediumBtagSFup*/const float &Common_event_mediumBtagSFup() { return vvv.Common_event_mediumBtagSFup(); }
+//---------------------------------------------------------------------------------
+/*             Common_event_mediumBtagSFdn*/const float &Common_event_mediumBtagSFdn() { return vvv.Common_event_mediumBtagSFdn(); }
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFHFup*/const float &Common_event_mediumBtagSFHFup() { return vvv.Common_event_mediumBtagSFHFup(); }
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFHFdn*/const float &Common_event_mediumBtagSFHFdn() { return vvv.Common_event_mediumBtagSFHFdn(); }
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFLFup*/const float &Common_event_mediumBtagSFLFup() { return vvv.Common_event_mediumBtagSFLFup(); }
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFLFdn*/const float &Common_event_mediumBtagSFLFdn() { return vvv.Common_event_mediumBtagSFLFdn(); }
+//---------------------------------------------------------------------------------
+/*                Common_event_looseBtagSF*/const float &Common_event_looseBtagSF() { return vvv.Common_event_looseBtagSF(); }
+//---------------------------------------------------------------------------------
+/*              Common_event_looseBtagSFup*/const float &Common_event_looseBtagSFup() { return vvv.Common_event_looseBtagSFup(); }
+//---------------------------------------------------------------------------------
+/*              Common_event_looseBtagSFdn*/const float &Common_event_looseBtagSFdn() { return vvv.Common_event_looseBtagSFdn(); }
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFHFup*/const float &Common_event_looseBtagSFHFup() { return vvv.Common_event_looseBtagSFHFup(); }
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFHFdn*/const float &Common_event_looseBtagSFHFdn() { return vvv.Common_event_looseBtagSFHFdn(); }
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFLFup*/const float &Common_event_looseBtagSFLFup() { return vvv.Common_event_looseBtagSFLFup(); }
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFLFdn*/const float &Common_event_looseBtagSFLFdn() { return vvv.Common_event_looseBtagSFLFdn(); }
 //---------------------------------------------------------------------------------
 /*                           Common_lep_p4*/const vector<ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > > &Common_lep_p4() { return vvv.Common_lep_p4(); }
 //---------------------------------------------------------------------------------
@@ -3274,11 +5286,31 @@ namespace tas {
 //---------------------------------------------------------------------------------
 /*                   Common_jet_passBtight*/const vector<bool> &Common_jet_passBtight() { return vvv.Common_jet_passBtight(); }
 //---------------------------------------------------------------------------------
+/*                           Common_jet_id*/const vector<int> &Common_jet_id() { return vvv.Common_jet_id(); }
+//---------------------------------------------------------------------------------
 /*                Common_jet_overlapfatjet*/const vector<int> &Common_jet_overlapfatjet() { return vvv.Common_jet_overlapfatjet(); }
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jesup*/const vector<float> &Common_jet_pt_jesup() { return vvv.Common_jet_pt_jesup(); }
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jesdn*/const vector<float> &Common_jet_pt_jesdn() { return vvv.Common_jet_pt_jesdn(); }
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jerup*/const vector<float> &Common_jet_pt_jerup() { return vvv.Common_jet_pt_jerup(); }
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jerdn*/const vector<float> &Common_jet_pt_jerdn() { return vvv.Common_jet_pt_jerdn(); }
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jesup*/const vector<float> &Common_jet_mass_jesup() { return vvv.Common_jet_mass_jesup(); }
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jesdn*/const vector<float> &Common_jet_mass_jesdn() { return vvv.Common_jet_mass_jesdn(); }
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jerup*/const vector<float> &Common_jet_mass_jerup() { return vvv.Common_jet_mass_jerup(); }
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jerdn*/const vector<float> &Common_jet_mass_jerdn() { return vvv.Common_jet_mass_jerdn(); }
 //---------------------------------------------------------------------------------
 /*                        Common_fatjet_p4*/const vector<ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > > &Common_fatjet_p4() { return vvv.Common_fatjet_p4(); }
 //---------------------------------------------------------------------------------
 /*                      Common_fatjet_idxs*/const vector<int> &Common_fatjet_idxs() { return vvv.Common_fatjet_idxs(); }
+//---------------------------------------------------------------------------------
+/*                        Common_fatjet_id*/const vector<int> &Common_fatjet_id() { return vvv.Common_fatjet_id(); }
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_msoftdrop*/const vector<float> &Common_fatjet_msoftdrop() { return vvv.Common_fatjet_msoftdrop(); }
 //---------------------------------------------------------------------------------
@@ -3295,6 +5327,24 @@ namespace tas {
 /*                    Common_fatjet_deep_T*/const vector<float> &Common_fatjet_deep_T() { return vvv.Common_fatjet_deep_T(); }
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_deepMD_bb*/const vector<float> &Common_fatjet_deepMD_bb() { return vvv.Common_fatjet_deepMD_bb(); }
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_particleNetMD_W*/const vector<float> &Common_fatjet_particleNetMD_W() { return vvv.Common_fatjet_particleNetMD_W(); }
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xqq*/const vector<float> &Common_fatjet_particleNetMD_Xqq() { return vvv.Common_fatjet_particleNetMD_Xqq(); }
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xcc*/const vector<float> &Common_fatjet_particleNetMD_Xcc() { return vvv.Common_fatjet_particleNetMD_Xcc(); }
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xbb*/const vector<float> &Common_fatjet_particleNetMD_Xbb() { return vvv.Common_fatjet_particleNetMD_Xbb(); }
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_QCD*/const vector<float> &Common_fatjet_particleNetMD_QCD() { return vvv.Common_fatjet_particleNetMD_QCD(); }
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_particleNet_QCD*/const vector<float> &Common_fatjet_particleNet_QCD() { return vvv.Common_fatjet_particleNet_QCD(); }
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_W*/const vector<float> &Common_fatjet_particleNet_W() { return vvv.Common_fatjet_particleNet_W(); }
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_Z*/const vector<float> &Common_fatjet_particleNet_Z() { return vvv.Common_fatjet_particleNet_Z(); }
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_T*/const vector<float> &Common_fatjet_particleNet_T() { return vvv.Common_fatjet_particleNet_T(); }
 //---------------------------------------------------------------------------------
 /*                      Common_fatjet_tau3*/const vector<float> &Common_fatjet_tau3() { return vvv.Common_fatjet_tau3(); }
 //---------------------------------------------------------------------------------
@@ -3328,6 +5378,8 @@ namespace tas {
 //---------------------------------------------------------------------------------
 /*                        Common_fatjet_WP*/const vector<int> &Common_fatjet_WP() { return vvv.Common_fatjet_WP(); }
 //---------------------------------------------------------------------------------
+/*                     Common_fatjet_WP_MD*/const vector<int> &Common_fatjet_WP_MD() { return vvv.Common_fatjet_WP_MD(); }
+//---------------------------------------------------------------------------------
 /*            Common_fatjet_WP_antimasscut*/const vector<int> &Common_fatjet_WP_antimasscut() { return vvv.Common_fatjet_WP_antimasscut(); }
 //---------------------------------------------------------------------------------
 /*                  Common_fatjet_SFVLoose*/const vector<float> &Common_fatjet_SFVLoose() { return vvv.Common_fatjet_SFVLoose(); }
@@ -3353,6 +5405,46 @@ namespace tas {
 /*                Common_fatjet_SFupMedium*/const vector<float> &Common_fatjet_SFupMedium() { return vvv.Common_fatjet_SFupMedium(); }
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_SFupTight*/const vector<float> &Common_fatjet_SFupTight() { return vvv.Common_fatjet_SFupTight(); }
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jesup*/const vector<float> &Common_fatjet_pt_jesup() { return vvv.Common_fatjet_pt_jesup(); }
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jesdn*/const vector<float> &Common_fatjet_pt_jesdn() { return vvv.Common_fatjet_pt_jesdn(); }
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jerup*/const vector<float> &Common_fatjet_pt_jerup() { return vvv.Common_fatjet_pt_jerup(); }
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jerdn*/const vector<float> &Common_fatjet_pt_jerdn() { return vvv.Common_fatjet_pt_jerdn(); }
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jesup*/const vector<float> &Common_fatjet_msoftdrop_jesup() { return vvv.Common_fatjet_msoftdrop_jesup(); }
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jesdn*/const vector<float> &Common_fatjet_msoftdrop_jesdn() { return vvv.Common_fatjet_msoftdrop_jesdn(); }
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jerup*/const vector<float> &Common_fatjet_msoftdrop_jerup() { return vvv.Common_fatjet_msoftdrop_jerup(); }
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jerdn*/const vector<float> &Common_fatjet_msoftdrop_jerdn() { return vvv.Common_fatjet_msoftdrop_jerdn(); }
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmsup*/const vector<float> &Common_fatjet_msoftdrop_jmsup() { return vvv.Common_fatjet_msoftdrop_jmsup(); }
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmsdn*/const vector<float> &Common_fatjet_msoftdrop_jmsdn() { return vvv.Common_fatjet_msoftdrop_jmsdn(); }
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmrup*/const vector<float> &Common_fatjet_msoftdrop_jmrup() { return vvv.Common_fatjet_msoftdrop_jmrup(); }
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmrdn*/const vector<float> &Common_fatjet_msoftdrop_jmrdn() { return vvv.Common_fatjet_msoftdrop_jmrdn(); }
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jesup*/const vector<float> &Common_fatjet_mass_jesup() { return vvv.Common_fatjet_mass_jesup(); }
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jesdn*/const vector<float> &Common_fatjet_mass_jesdn() { return vvv.Common_fatjet_mass_jesdn(); }
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jerup*/const vector<float> &Common_fatjet_mass_jerup() { return vvv.Common_fatjet_mass_jerup(); }
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jerdn*/const vector<float> &Common_fatjet_mass_jerdn() { return vvv.Common_fatjet_mass_jerdn(); }
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmsup*/const vector<float> &Common_fatjet_mass_jmsup() { return vvv.Common_fatjet_mass_jmsup(); }
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmsdn*/const vector<float> &Common_fatjet_mass_jmsdn() { return vvv.Common_fatjet_mass_jmsdn(); }
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmrup*/const vector<float> &Common_fatjet_mass_jmrup() { return vvv.Common_fatjet_mass_jmrup(); }
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmrdn*/const vector<float> &Common_fatjet_mass_jmrdn() { return vvv.Common_fatjet_mass_jmrdn(); }
 //---------------------------------------------------------------------------------
 /*      Common_eventweight_fatjet_SFVLoose*/const float &Common_eventweight_fatjet_SFVLoose() { return vvv.Common_eventweight_fatjet_SFVLoose(); }
 //---------------------------------------------------------------------------------
@@ -3405,6 +5497,8 @@ namespace tas {
 /*                 Common_gen_vvvdecay_p4s*/const vector<ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > > &Common_gen_vvvdecay_p4s() { return vvv.Common_gen_vvvdecay_p4s(); }
 //---------------------------------------------------------------------------------
 /*          Common_gen_vvvdecay_taudecayid*/const vector<int> &Common_gen_vvvdecay_taudecayid() { return vvv.Common_gen_vvvdecay_taudecayid(); }
+//---------------------------------------------------------------------------------
+/*                         Common_isSignal*/const bool &Common_isSignal() { return vvv.Common_isSignal(); }
 //---------------------------------------------------------------------------------
 /*                              Common_n_W*/const int &Common_n_W() { return vvv.Common_n_W(); }
 //---------------------------------------------------------------------------------

--- a/src/VVVTree.h
+++ b/src/VVVTree.h
@@ -1,6 +1,6 @@
 // -*- C++ -*-
 // This is a header file generated with the command:
-// makeCMS3ClassFiles("/home/users/phchang/public_html/analysis/vvv/VVVNanoLooper__/debug.root", "t", "VVVTree", "tas", "vvv")
+// makeCMS3ClassFiles("/uscms/home/horyn/nobackup/vvv/VVVNanoLooper_clean/qcd_test_UL18.root", "t", "VVVTree", "tas", "vvv")
 
 #ifndef VVVTree_H
 #define VVVTree_H
@@ -48,6 +48,46 @@ class VVVTree {
 /*              Common_btagWeight_DeepCSVB*/  TBranch *Common_btagWeight_DeepCSVB_branch;
 /*              Common_btagWeight_DeepCSVB*/  bool     Common_btagWeight_DeepCSVB_isLoaded;
 //---------------------------------------------------------------------------------
+/*                              Common_wgt*/  float    Common_wgt_;
+/*                              Common_wgt*/  TBranch *Common_wgt_branch;
+/*                              Common_wgt*/  bool     Common_wgt_isLoaded;
+//---------------------------------------------------------------------------------
+/*                   Common_event_puWeight*/  float    Common_event_puWeight_;
+/*                   Common_event_puWeight*/  TBranch *Common_event_puWeight_branch;
+/*                   Common_event_puWeight*/  bool     Common_event_puWeight_isLoaded;
+//---------------------------------------------------------------------------------
+/*                 Common_event_puWeightup*/  float    Common_event_puWeightup_;
+/*                 Common_event_puWeightup*/  TBranch *Common_event_puWeightup_branch;
+/*                 Common_event_puWeightup*/  bool     Common_event_puWeightup_isLoaded;
+//---------------------------------------------------------------------------------
+/*                 Common_event_puWeightdn*/  float    Common_event_puWeightdn_;
+/*                 Common_event_puWeightdn*/  TBranch *Common_event_puWeightdn_branch;
+/*                 Common_event_puWeightdn*/  bool     Common_event_puWeightdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*              Common_event_prefireWeight*/  float    Common_event_prefireWeight_;
+/*              Common_event_prefireWeight*/  TBranch *Common_event_prefireWeight_branch;
+/*              Common_event_prefireWeight*/  bool     Common_event_prefireWeight_isLoaded;
+//---------------------------------------------------------------------------------
+/*            Common_event_prefireWeightup*/  float    Common_event_prefireWeightup_;
+/*            Common_event_prefireWeightup*/  TBranch *Common_event_prefireWeightup_branch;
+/*            Common_event_prefireWeightup*/  bool     Common_event_prefireWeightup_isLoaded;
+//---------------------------------------------------------------------------------
+/*            Common_event_prefireWeightdn*/  float    Common_event_prefireWeightdn_;
+/*            Common_event_prefireWeightdn*/  TBranch *Common_event_prefireWeightdn_branch;
+/*            Common_event_prefireWeightdn*/  bool     Common_event_prefireWeightdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*              Common_event_triggerWeight*/  float    Common_event_triggerWeight_;
+/*              Common_event_triggerWeight*/  TBranch *Common_event_triggerWeight_branch;
+/*              Common_event_triggerWeight*/  bool     Common_event_triggerWeight_isLoaded;
+//---------------------------------------------------------------------------------
+/*            Common_event_triggerWeightup*/  float    Common_event_triggerWeightup_;
+/*            Common_event_triggerWeightup*/  TBranch *Common_event_triggerWeightup_branch;
+/*            Common_event_triggerWeightup*/  bool     Common_event_triggerWeightup_isLoaded;
+//---------------------------------------------------------------------------------
+/*            Common_event_triggerWeightdn*/  float    Common_event_triggerWeightdn_;
+/*            Common_event_triggerWeightdn*/  TBranch *Common_event_triggerWeightdn_branch;
+/*            Common_event_triggerWeightdn*/  bool     Common_event_triggerWeightdn_isLoaded;
+//---------------------------------------------------------------------------------
 /*         Common_LHEWeight_mg_reweighting*/  vector<float> *Common_LHEWeight_mg_reweighting_;
 /*         Common_LHEWeight_mg_reweighting*/  TBranch *Common_LHEWeight_mg_reweighting_branch;
 /*         Common_LHEWeight_mg_reweighting*/  bool     Common_LHEWeight_mg_reweighting_isLoaded;
@@ -88,6 +128,46 @@ class VVVTree {
 /*Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL*/  TBranch *Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_branch;
 /*Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL*/  bool     Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_isLoaded;
 //---------------------------------------------------------------------------------
+/*                     Common_HLT_PFHT1050*/  bool     Common_HLT_PFHT1050_;
+/*                     Common_HLT_PFHT1050*/  TBranch *Common_HLT_PFHT1050_branch;
+/*                     Common_HLT_PFHT1050*/  bool     Common_HLT_PFHT1050_isLoaded;
+//---------------------------------------------------------------------------------
+/*                  Common_HLT_AK8PFJet500*/  bool     Common_HLT_AK8PFJet500_;
+/*                  Common_HLT_AK8PFJet500*/  TBranch *Common_HLT_AK8PFJet500_branch;
+/*                  Common_HLT_AK8PFJet500*/  bool     Common_HLT_AK8PFJet500_isLoaded;
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet380_TrimMass30*/  bool     Common_HLT_AK8PFJet380_TrimMass30_;
+/*       Common_HLT_AK8PFJet380_TrimMass30*/  TBranch *Common_HLT_AK8PFJet380_TrimMass30_branch;
+/*       Common_HLT_AK8PFJet380_TrimMass30*/  bool     Common_HLT_AK8PFJet380_TrimMass30_isLoaded;
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet360_TrimMass30*/  bool     Common_HLT_AK8PFJet360_TrimMass30_;
+/*       Common_HLT_AK8PFJet360_TrimMass30*/  TBranch *Common_HLT_AK8PFJet360_TrimMass30_branch;
+/*       Common_HLT_AK8PFJet360_TrimMass30*/  bool     Common_HLT_AK8PFJet360_TrimMass30_isLoaded;
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet400_TrimMass30*/  bool     Common_HLT_AK8PFJet400_TrimMass30_;
+/*       Common_HLT_AK8PFJet400_TrimMass30*/  TBranch *Common_HLT_AK8PFJet400_TrimMass30_branch;
+/*       Common_HLT_AK8PFJet400_TrimMass30*/  bool     Common_HLT_AK8PFJet400_TrimMass30_isLoaded;
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet420_TrimMass30*/  bool     Common_HLT_AK8PFJet420_TrimMass30_;
+/*       Common_HLT_AK8PFJet420_TrimMass30*/  TBranch *Common_HLT_AK8PFJet420_TrimMass30_branch;
+/*       Common_HLT_AK8PFJet420_TrimMass30*/  bool     Common_HLT_AK8PFJet420_TrimMass30_isLoaded;
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT750_TrimMass50*/  bool     Common_HLT_AK8PFHT750_TrimMass50_;
+/*        Common_HLT_AK8PFHT750_TrimMass50*/  TBranch *Common_HLT_AK8PFHT750_TrimMass50_branch;
+/*        Common_HLT_AK8PFHT750_TrimMass50*/  bool     Common_HLT_AK8PFHT750_TrimMass50_isLoaded;
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT800_TrimMass50*/  bool     Common_HLT_AK8PFHT800_TrimMass50_;
+/*        Common_HLT_AK8PFHT800_TrimMass50*/  TBranch *Common_HLT_AK8PFHT800_TrimMass50_branch;
+/*        Common_HLT_AK8PFHT800_TrimMass50*/  bool     Common_HLT_AK8PFHT800_TrimMass50_isLoaded;
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT850_TrimMass50*/  bool     Common_HLT_AK8PFHT850_TrimMass50_;
+/*        Common_HLT_AK8PFHT850_TrimMass50*/  TBranch *Common_HLT_AK8PFHT850_TrimMass50_branch;
+/*        Common_HLT_AK8PFHT850_TrimMass50*/  bool     Common_HLT_AK8PFHT850_TrimMass50_isLoaded;
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT900_TrimMass50*/  bool     Common_HLT_AK8PFHT900_TrimMass50_;
+/*        Common_HLT_AK8PFHT900_TrimMass50*/  TBranch *Common_HLT_AK8PFHT900_TrimMass50_branch;
+/*        Common_HLT_AK8PFHT900_TrimMass50*/  bool     Common_HLT_AK8PFHT900_TrimMass50_isLoaded;
+//---------------------------------------------------------------------------------
 /*                     Common_HLT_DoubleEl*/  bool     Common_HLT_DoubleEl_;
 /*                     Common_HLT_DoubleEl*/  TBranch *Common_HLT_DoubleEl_branch;
 /*                     Common_HLT_DoubleEl*/  bool     Common_HLT_DoubleEl_isLoaded;
@@ -124,6 +204,22 @@ class VVVTree {
 /*                           Common_met_p4*/  TBranch *Common_met_p4_branch;
 /*                           Common_met_p4*/  bool     Common_met_p4_isLoaded;
 //---------------------------------------------------------------------------------
+/*                     Common_met_p4_jesup*/  ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > *Common_met_p4_jesup_;
+/*                     Common_met_p4_jesup*/  TBranch *Common_met_p4_jesup_branch;
+/*                     Common_met_p4_jesup*/  bool     Common_met_p4_jesup_isLoaded;
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jesdn*/  ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > *Common_met_p4_jesdn_;
+/*                     Common_met_p4_jesdn*/  TBranch *Common_met_p4_jesdn_branch;
+/*                     Common_met_p4_jesdn*/  bool     Common_met_p4_jesdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jerup*/  ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > *Common_met_p4_jerup_;
+/*                     Common_met_p4_jerup*/  TBranch *Common_met_p4_jerup_branch;
+/*                     Common_met_p4_jerup*/  bool     Common_met_p4_jerup_isLoaded;
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jerdn*/  ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > *Common_met_p4_jerdn_;
+/*                     Common_met_p4_jerdn*/  TBranch *Common_met_p4_jerdn_branch;
+/*                     Common_met_p4_jerdn*/  bool     Common_met_p4_jerdn_isLoaded;
+//---------------------------------------------------------------------------------
 /*                      Common_event_lepSF*/  float    Common_event_lepSF_;
 /*                      Common_event_lepSF*/  TBranch *Common_event_lepSF_branch;
 /*                      Common_event_lepSF*/  bool     Common_event_lepSF_isLoaded;
@@ -143,6 +239,110 @@ class VVVTree {
 /*                  Common_event_lepSFmudn*/  float    Common_event_lepSFmudn_;
 /*                  Common_event_lepSFmudn*/  TBranch *Common_event_lepSFmudn_branch;
 /*                  Common_event_lepSFmudn*/  bool     Common_event_lepSFmudn_isLoaded;
+//---------------------------------------------------------------------------------
+/*                 Common_event_lepSFTight*/  float    Common_event_lepSFTight_;
+/*                 Common_event_lepSFTight*/  TBranch *Common_event_lepSFTight_branch;
+/*                 Common_event_lepSFTight*/  bool     Common_event_lepSFTight_isLoaded;
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFelupTight*/  float    Common_event_lepSFelupTight_;
+/*             Common_event_lepSFelupTight*/  TBranch *Common_event_lepSFelupTight_branch;
+/*             Common_event_lepSFelupTight*/  bool     Common_event_lepSFelupTight_isLoaded;
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFeldnTight*/  float    Common_event_lepSFeldnTight_;
+/*             Common_event_lepSFeldnTight*/  TBranch *Common_event_lepSFeldnTight_branch;
+/*             Common_event_lepSFeldnTight*/  bool     Common_event_lepSFeldnTight_isLoaded;
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFmuupTight*/  float    Common_event_lepSFmuupTight_;
+/*             Common_event_lepSFmuupTight*/  TBranch *Common_event_lepSFmuupTight_branch;
+/*             Common_event_lepSFmuupTight*/  bool     Common_event_lepSFmuupTight_isLoaded;
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFmudnTight*/  float    Common_event_lepSFmudnTight_;
+/*             Common_event_lepSFmudnTight*/  TBranch *Common_event_lepSFmudnTight_branch;
+/*             Common_event_lepSFmudnTight*/  bool     Common_event_lepSFmudnTight_isLoaded;
+//---------------------------------------------------------------------------------
+/*                Common_event_tightBtagSF*/  float    Common_event_tightBtagSF_;
+/*                Common_event_tightBtagSF*/  TBranch *Common_event_tightBtagSF_branch;
+/*                Common_event_tightBtagSF*/  bool     Common_event_tightBtagSF_isLoaded;
+//---------------------------------------------------------------------------------
+/*              Common_event_tightBtagSFup*/  float    Common_event_tightBtagSFup_;
+/*              Common_event_tightBtagSFup*/  TBranch *Common_event_tightBtagSFup_branch;
+/*              Common_event_tightBtagSFup*/  bool     Common_event_tightBtagSFup_isLoaded;
+//---------------------------------------------------------------------------------
+/*              Common_event_tightBtagSFdn*/  float    Common_event_tightBtagSFdn_;
+/*              Common_event_tightBtagSFdn*/  TBranch *Common_event_tightBtagSFdn_branch;
+/*              Common_event_tightBtagSFdn*/  bool     Common_event_tightBtagSFdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFHFup*/  float    Common_event_tightBtagSFHFup_;
+/*            Common_event_tightBtagSFHFup*/  TBranch *Common_event_tightBtagSFHFup_branch;
+/*            Common_event_tightBtagSFHFup*/  bool     Common_event_tightBtagSFHFup_isLoaded;
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFHFdn*/  float    Common_event_tightBtagSFHFdn_;
+/*            Common_event_tightBtagSFHFdn*/  TBranch *Common_event_tightBtagSFHFdn_branch;
+/*            Common_event_tightBtagSFHFdn*/  bool     Common_event_tightBtagSFHFdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFLFup*/  float    Common_event_tightBtagSFLFup_;
+/*            Common_event_tightBtagSFLFup*/  TBranch *Common_event_tightBtagSFLFup_branch;
+/*            Common_event_tightBtagSFLFup*/  bool     Common_event_tightBtagSFLFup_isLoaded;
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFLFdn*/  float    Common_event_tightBtagSFLFdn_;
+/*            Common_event_tightBtagSFLFdn*/  TBranch *Common_event_tightBtagSFLFdn_branch;
+/*            Common_event_tightBtagSFLFdn*/  bool     Common_event_tightBtagSFLFdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*               Common_event_mediumBtagSF*/  float    Common_event_mediumBtagSF_;
+/*               Common_event_mediumBtagSF*/  TBranch *Common_event_mediumBtagSF_branch;
+/*               Common_event_mediumBtagSF*/  bool     Common_event_mediumBtagSF_isLoaded;
+//---------------------------------------------------------------------------------
+/*             Common_event_mediumBtagSFup*/  float    Common_event_mediumBtagSFup_;
+/*             Common_event_mediumBtagSFup*/  TBranch *Common_event_mediumBtagSFup_branch;
+/*             Common_event_mediumBtagSFup*/  bool     Common_event_mediumBtagSFup_isLoaded;
+//---------------------------------------------------------------------------------
+/*             Common_event_mediumBtagSFdn*/  float    Common_event_mediumBtagSFdn_;
+/*             Common_event_mediumBtagSFdn*/  TBranch *Common_event_mediumBtagSFdn_branch;
+/*             Common_event_mediumBtagSFdn*/  bool     Common_event_mediumBtagSFdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFHFup*/  float    Common_event_mediumBtagSFHFup_;
+/*           Common_event_mediumBtagSFHFup*/  TBranch *Common_event_mediumBtagSFHFup_branch;
+/*           Common_event_mediumBtagSFHFup*/  bool     Common_event_mediumBtagSFHFup_isLoaded;
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFHFdn*/  float    Common_event_mediumBtagSFHFdn_;
+/*           Common_event_mediumBtagSFHFdn*/  TBranch *Common_event_mediumBtagSFHFdn_branch;
+/*           Common_event_mediumBtagSFHFdn*/  bool     Common_event_mediumBtagSFHFdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFLFup*/  float    Common_event_mediumBtagSFLFup_;
+/*           Common_event_mediumBtagSFLFup*/  TBranch *Common_event_mediumBtagSFLFup_branch;
+/*           Common_event_mediumBtagSFLFup*/  bool     Common_event_mediumBtagSFLFup_isLoaded;
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFLFdn*/  float    Common_event_mediumBtagSFLFdn_;
+/*           Common_event_mediumBtagSFLFdn*/  TBranch *Common_event_mediumBtagSFLFdn_branch;
+/*           Common_event_mediumBtagSFLFdn*/  bool     Common_event_mediumBtagSFLFdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*                Common_event_looseBtagSF*/  float    Common_event_looseBtagSF_;
+/*                Common_event_looseBtagSF*/  TBranch *Common_event_looseBtagSF_branch;
+/*                Common_event_looseBtagSF*/  bool     Common_event_looseBtagSF_isLoaded;
+//---------------------------------------------------------------------------------
+/*              Common_event_looseBtagSFup*/  float    Common_event_looseBtagSFup_;
+/*              Common_event_looseBtagSFup*/  TBranch *Common_event_looseBtagSFup_branch;
+/*              Common_event_looseBtagSFup*/  bool     Common_event_looseBtagSFup_isLoaded;
+//---------------------------------------------------------------------------------
+/*              Common_event_looseBtagSFdn*/  float    Common_event_looseBtagSFdn_;
+/*              Common_event_looseBtagSFdn*/  TBranch *Common_event_looseBtagSFdn_branch;
+/*              Common_event_looseBtagSFdn*/  bool     Common_event_looseBtagSFdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFHFup*/  float    Common_event_looseBtagSFHFup_;
+/*            Common_event_looseBtagSFHFup*/  TBranch *Common_event_looseBtagSFHFup_branch;
+/*            Common_event_looseBtagSFHFup*/  bool     Common_event_looseBtagSFHFup_isLoaded;
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFHFdn*/  float    Common_event_looseBtagSFHFdn_;
+/*            Common_event_looseBtagSFHFdn*/  TBranch *Common_event_looseBtagSFHFdn_branch;
+/*            Common_event_looseBtagSFHFdn*/  bool     Common_event_looseBtagSFHFdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFLFup*/  float    Common_event_looseBtagSFLFup_;
+/*            Common_event_looseBtagSFLFup*/  TBranch *Common_event_looseBtagSFLFup_branch;
+/*            Common_event_looseBtagSFLFup*/  bool     Common_event_looseBtagSFLFup_isLoaded;
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFLFdn*/  float    Common_event_looseBtagSFLFdn_;
+/*            Common_event_looseBtagSFLFdn*/  TBranch *Common_event_looseBtagSFLFdn_branch;
+/*            Common_event_looseBtagSFLFdn*/  bool     Common_event_looseBtagSFLFdn_isLoaded;
 //---------------------------------------------------------------------------------
 /*                           Common_lep_p4*/  vector<ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > > *Common_lep_p4_;
 /*                           Common_lep_p4*/  TBranch *Common_lep_p4_branch;
@@ -220,9 +420,45 @@ class VVVTree {
 /*                   Common_jet_passBtight*/  TBranch *Common_jet_passBtight_branch;
 /*                   Common_jet_passBtight*/  bool     Common_jet_passBtight_isLoaded;
 //---------------------------------------------------------------------------------
+/*                           Common_jet_id*/  vector<int> *Common_jet_id_;
+/*                           Common_jet_id*/  TBranch *Common_jet_id_branch;
+/*                           Common_jet_id*/  bool     Common_jet_id_isLoaded;
+//---------------------------------------------------------------------------------
 /*                Common_jet_overlapfatjet*/  vector<int> *Common_jet_overlapfatjet_;
 /*                Common_jet_overlapfatjet*/  TBranch *Common_jet_overlapfatjet_branch;
 /*                Common_jet_overlapfatjet*/  bool     Common_jet_overlapfatjet_isLoaded;
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jesup*/  vector<float> *Common_jet_pt_jesup_;
+/*                     Common_jet_pt_jesup*/  TBranch *Common_jet_pt_jesup_branch;
+/*                     Common_jet_pt_jesup*/  bool     Common_jet_pt_jesup_isLoaded;
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jesdn*/  vector<float> *Common_jet_pt_jesdn_;
+/*                     Common_jet_pt_jesdn*/  TBranch *Common_jet_pt_jesdn_branch;
+/*                     Common_jet_pt_jesdn*/  bool     Common_jet_pt_jesdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jerup*/  vector<float> *Common_jet_pt_jerup_;
+/*                     Common_jet_pt_jerup*/  TBranch *Common_jet_pt_jerup_branch;
+/*                     Common_jet_pt_jerup*/  bool     Common_jet_pt_jerup_isLoaded;
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jerdn*/  vector<float> *Common_jet_pt_jerdn_;
+/*                     Common_jet_pt_jerdn*/  TBranch *Common_jet_pt_jerdn_branch;
+/*                     Common_jet_pt_jerdn*/  bool     Common_jet_pt_jerdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jesup*/  vector<float> *Common_jet_mass_jesup_;
+/*                   Common_jet_mass_jesup*/  TBranch *Common_jet_mass_jesup_branch;
+/*                   Common_jet_mass_jesup*/  bool     Common_jet_mass_jesup_isLoaded;
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jesdn*/  vector<float> *Common_jet_mass_jesdn_;
+/*                   Common_jet_mass_jesdn*/  TBranch *Common_jet_mass_jesdn_branch;
+/*                   Common_jet_mass_jesdn*/  bool     Common_jet_mass_jesdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jerup*/  vector<float> *Common_jet_mass_jerup_;
+/*                   Common_jet_mass_jerup*/  TBranch *Common_jet_mass_jerup_branch;
+/*                   Common_jet_mass_jerup*/  bool     Common_jet_mass_jerup_isLoaded;
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jerdn*/  vector<float> *Common_jet_mass_jerdn_;
+/*                   Common_jet_mass_jerdn*/  TBranch *Common_jet_mass_jerdn_branch;
+/*                   Common_jet_mass_jerdn*/  bool     Common_jet_mass_jerdn_isLoaded;
 //---------------------------------------------------------------------------------
 /*                        Common_fatjet_p4*/  vector<ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > > *Common_fatjet_p4_;
 /*                        Common_fatjet_p4*/  TBranch *Common_fatjet_p4_branch;
@@ -231,6 +467,10 @@ class VVVTree {
 /*                      Common_fatjet_idxs*/  vector<int> *Common_fatjet_idxs_;
 /*                      Common_fatjet_idxs*/  TBranch *Common_fatjet_idxs_branch;
 /*                      Common_fatjet_idxs*/  bool     Common_fatjet_idxs_isLoaded;
+//---------------------------------------------------------------------------------
+/*                        Common_fatjet_id*/  vector<int> *Common_fatjet_id_;
+/*                        Common_fatjet_id*/  TBranch *Common_fatjet_id_branch;
+/*                        Common_fatjet_id*/  bool     Common_fatjet_id_isLoaded;
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_msoftdrop*/  vector<float> *Common_fatjet_msoftdrop_;
 /*                 Common_fatjet_msoftdrop*/  TBranch *Common_fatjet_msoftdrop_branch;
@@ -263,6 +503,42 @@ class VVVTree {
 /*                 Common_fatjet_deepMD_bb*/  vector<float> *Common_fatjet_deepMD_bb_;
 /*                 Common_fatjet_deepMD_bb*/  TBranch *Common_fatjet_deepMD_bb_branch;
 /*                 Common_fatjet_deepMD_bb*/  bool     Common_fatjet_deepMD_bb_isLoaded;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_particleNetMD_W*/  vector<float> *Common_fatjet_particleNetMD_W_;
+/*           Common_fatjet_particleNetMD_W*/  TBranch *Common_fatjet_particleNetMD_W_branch;
+/*           Common_fatjet_particleNetMD_W*/  bool     Common_fatjet_particleNetMD_W_isLoaded;
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xqq*/  vector<float> *Common_fatjet_particleNetMD_Xqq_;
+/*         Common_fatjet_particleNetMD_Xqq*/  TBranch *Common_fatjet_particleNetMD_Xqq_branch;
+/*         Common_fatjet_particleNetMD_Xqq*/  bool     Common_fatjet_particleNetMD_Xqq_isLoaded;
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xcc*/  vector<float> *Common_fatjet_particleNetMD_Xcc_;
+/*         Common_fatjet_particleNetMD_Xcc*/  TBranch *Common_fatjet_particleNetMD_Xcc_branch;
+/*         Common_fatjet_particleNetMD_Xcc*/  bool     Common_fatjet_particleNetMD_Xcc_isLoaded;
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xbb*/  vector<float> *Common_fatjet_particleNetMD_Xbb_;
+/*         Common_fatjet_particleNetMD_Xbb*/  TBranch *Common_fatjet_particleNetMD_Xbb_branch;
+/*         Common_fatjet_particleNetMD_Xbb*/  bool     Common_fatjet_particleNetMD_Xbb_isLoaded;
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_QCD*/  vector<float> *Common_fatjet_particleNetMD_QCD_;
+/*         Common_fatjet_particleNetMD_QCD*/  TBranch *Common_fatjet_particleNetMD_QCD_branch;
+/*         Common_fatjet_particleNetMD_QCD*/  bool     Common_fatjet_particleNetMD_QCD_isLoaded;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_particleNet_QCD*/  vector<float> *Common_fatjet_particleNet_QCD_;
+/*           Common_fatjet_particleNet_QCD*/  TBranch *Common_fatjet_particleNet_QCD_branch;
+/*           Common_fatjet_particleNet_QCD*/  bool     Common_fatjet_particleNet_QCD_isLoaded;
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_W*/  vector<float> *Common_fatjet_particleNet_W_;
+/*             Common_fatjet_particleNet_W*/  TBranch *Common_fatjet_particleNet_W_branch;
+/*             Common_fatjet_particleNet_W*/  bool     Common_fatjet_particleNet_W_isLoaded;
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_Z*/  vector<float> *Common_fatjet_particleNet_Z_;
+/*             Common_fatjet_particleNet_Z*/  TBranch *Common_fatjet_particleNet_Z_branch;
+/*             Common_fatjet_particleNet_Z*/  bool     Common_fatjet_particleNet_Z_isLoaded;
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_T*/  vector<float> *Common_fatjet_particleNet_T_;
+/*             Common_fatjet_particleNet_T*/  TBranch *Common_fatjet_particleNet_T_branch;
+/*             Common_fatjet_particleNet_T*/  bool     Common_fatjet_particleNet_T_isLoaded;
 //---------------------------------------------------------------------------------
 /*                      Common_fatjet_tau3*/  vector<float> *Common_fatjet_tau3_;
 /*                      Common_fatjet_tau3*/  TBranch *Common_fatjet_tau3_branch;
@@ -328,6 +604,10 @@ class VVVTree {
 /*                        Common_fatjet_WP*/  TBranch *Common_fatjet_WP_branch;
 /*                        Common_fatjet_WP*/  bool     Common_fatjet_WP_isLoaded;
 //---------------------------------------------------------------------------------
+/*                     Common_fatjet_WP_MD*/  vector<int> *Common_fatjet_WP_MD_;
+/*                     Common_fatjet_WP_MD*/  TBranch *Common_fatjet_WP_MD_branch;
+/*                     Common_fatjet_WP_MD*/  bool     Common_fatjet_WP_MD_isLoaded;
+//---------------------------------------------------------------------------------
 /*            Common_fatjet_WP_antimasscut*/  vector<int> *Common_fatjet_WP_antimasscut_;
 /*            Common_fatjet_WP_antimasscut*/  TBranch *Common_fatjet_WP_antimasscut_branch;
 /*            Common_fatjet_WP_antimasscut*/  bool     Common_fatjet_WP_antimasscut_isLoaded;
@@ -379,6 +659,86 @@ class VVVTree {
 /*                 Common_fatjet_SFupTight*/  vector<float> *Common_fatjet_SFupTight_;
 /*                 Common_fatjet_SFupTight*/  TBranch *Common_fatjet_SFupTight_branch;
 /*                 Common_fatjet_SFupTight*/  bool     Common_fatjet_SFupTight_isLoaded;
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jesup*/  vector<float> *Common_fatjet_pt_jesup_;
+/*                  Common_fatjet_pt_jesup*/  TBranch *Common_fatjet_pt_jesup_branch;
+/*                  Common_fatjet_pt_jesup*/  bool     Common_fatjet_pt_jesup_isLoaded;
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jesdn*/  vector<float> *Common_fatjet_pt_jesdn_;
+/*                  Common_fatjet_pt_jesdn*/  TBranch *Common_fatjet_pt_jesdn_branch;
+/*                  Common_fatjet_pt_jesdn*/  bool     Common_fatjet_pt_jesdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jerup*/  vector<float> *Common_fatjet_pt_jerup_;
+/*                  Common_fatjet_pt_jerup*/  TBranch *Common_fatjet_pt_jerup_branch;
+/*                  Common_fatjet_pt_jerup*/  bool     Common_fatjet_pt_jerup_isLoaded;
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jerdn*/  vector<float> *Common_fatjet_pt_jerdn_;
+/*                  Common_fatjet_pt_jerdn*/  TBranch *Common_fatjet_pt_jerdn_branch;
+/*                  Common_fatjet_pt_jerdn*/  bool     Common_fatjet_pt_jerdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jesup*/  vector<float> *Common_fatjet_msoftdrop_jesup_;
+/*           Common_fatjet_msoftdrop_jesup*/  TBranch *Common_fatjet_msoftdrop_jesup_branch;
+/*           Common_fatjet_msoftdrop_jesup*/  bool     Common_fatjet_msoftdrop_jesup_isLoaded;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jesdn*/  vector<float> *Common_fatjet_msoftdrop_jesdn_;
+/*           Common_fatjet_msoftdrop_jesdn*/  TBranch *Common_fatjet_msoftdrop_jesdn_branch;
+/*           Common_fatjet_msoftdrop_jesdn*/  bool     Common_fatjet_msoftdrop_jesdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jerup*/  vector<float> *Common_fatjet_msoftdrop_jerup_;
+/*           Common_fatjet_msoftdrop_jerup*/  TBranch *Common_fatjet_msoftdrop_jerup_branch;
+/*           Common_fatjet_msoftdrop_jerup*/  bool     Common_fatjet_msoftdrop_jerup_isLoaded;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jerdn*/  vector<float> *Common_fatjet_msoftdrop_jerdn_;
+/*           Common_fatjet_msoftdrop_jerdn*/  TBranch *Common_fatjet_msoftdrop_jerdn_branch;
+/*           Common_fatjet_msoftdrop_jerdn*/  bool     Common_fatjet_msoftdrop_jerdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmsup*/  vector<float> *Common_fatjet_msoftdrop_jmsup_;
+/*           Common_fatjet_msoftdrop_jmsup*/  TBranch *Common_fatjet_msoftdrop_jmsup_branch;
+/*           Common_fatjet_msoftdrop_jmsup*/  bool     Common_fatjet_msoftdrop_jmsup_isLoaded;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmsdn*/  vector<float> *Common_fatjet_msoftdrop_jmsdn_;
+/*           Common_fatjet_msoftdrop_jmsdn*/  TBranch *Common_fatjet_msoftdrop_jmsdn_branch;
+/*           Common_fatjet_msoftdrop_jmsdn*/  bool     Common_fatjet_msoftdrop_jmsdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmrup*/  vector<float> *Common_fatjet_msoftdrop_jmrup_;
+/*           Common_fatjet_msoftdrop_jmrup*/  TBranch *Common_fatjet_msoftdrop_jmrup_branch;
+/*           Common_fatjet_msoftdrop_jmrup*/  bool     Common_fatjet_msoftdrop_jmrup_isLoaded;
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmrdn*/  vector<float> *Common_fatjet_msoftdrop_jmrdn_;
+/*           Common_fatjet_msoftdrop_jmrdn*/  TBranch *Common_fatjet_msoftdrop_jmrdn_branch;
+/*           Common_fatjet_msoftdrop_jmrdn*/  bool     Common_fatjet_msoftdrop_jmrdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jesup*/  vector<float> *Common_fatjet_mass_jesup_;
+/*                Common_fatjet_mass_jesup*/  TBranch *Common_fatjet_mass_jesup_branch;
+/*                Common_fatjet_mass_jesup*/  bool     Common_fatjet_mass_jesup_isLoaded;
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jesdn*/  vector<float> *Common_fatjet_mass_jesdn_;
+/*                Common_fatjet_mass_jesdn*/  TBranch *Common_fatjet_mass_jesdn_branch;
+/*                Common_fatjet_mass_jesdn*/  bool     Common_fatjet_mass_jesdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jerup*/  vector<float> *Common_fatjet_mass_jerup_;
+/*                Common_fatjet_mass_jerup*/  TBranch *Common_fatjet_mass_jerup_branch;
+/*                Common_fatjet_mass_jerup*/  bool     Common_fatjet_mass_jerup_isLoaded;
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jerdn*/  vector<float> *Common_fatjet_mass_jerdn_;
+/*                Common_fatjet_mass_jerdn*/  TBranch *Common_fatjet_mass_jerdn_branch;
+/*                Common_fatjet_mass_jerdn*/  bool     Common_fatjet_mass_jerdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmsup*/  vector<float> *Common_fatjet_mass_jmsup_;
+/*                Common_fatjet_mass_jmsup*/  TBranch *Common_fatjet_mass_jmsup_branch;
+/*                Common_fatjet_mass_jmsup*/  bool     Common_fatjet_mass_jmsup_isLoaded;
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmsdn*/  vector<float> *Common_fatjet_mass_jmsdn_;
+/*                Common_fatjet_mass_jmsdn*/  TBranch *Common_fatjet_mass_jmsdn_branch;
+/*                Common_fatjet_mass_jmsdn*/  bool     Common_fatjet_mass_jmsdn_isLoaded;
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmrup*/  vector<float> *Common_fatjet_mass_jmrup_;
+/*                Common_fatjet_mass_jmrup*/  TBranch *Common_fatjet_mass_jmrup_branch;
+/*                Common_fatjet_mass_jmrup*/  bool     Common_fatjet_mass_jmrup_isLoaded;
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmrdn*/  vector<float> *Common_fatjet_mass_jmrdn_;
+/*                Common_fatjet_mass_jmrdn*/  TBranch *Common_fatjet_mass_jmrdn_branch;
+/*                Common_fatjet_mass_jmrdn*/  bool     Common_fatjet_mass_jmrdn_isLoaded;
 //---------------------------------------------------------------------------------
 /*      Common_eventweight_fatjet_SFVLoose*/  float    Common_eventweight_fatjet_SFVLoose_;
 /*      Common_eventweight_fatjet_SFVLoose*/  TBranch *Common_eventweight_fatjet_SFVLoose_branch;
@@ -483,6 +843,10 @@ class VVVTree {
 /*          Common_gen_vvvdecay_taudecayid*/  vector<int> *Common_gen_vvvdecay_taudecayid_;
 /*          Common_gen_vvvdecay_taudecayid*/  TBranch *Common_gen_vvvdecay_taudecayid_branch;
 /*          Common_gen_vvvdecay_taudecayid*/  bool     Common_gen_vvvdecay_taudecayid_isLoaded;
+//---------------------------------------------------------------------------------
+/*                         Common_isSignal*/  bool     Common_isSignal_;
+/*                         Common_isSignal*/  TBranch *Common_isSignal_branch;
+/*                         Common_isSignal*/  bool     Common_isSignal_isLoaded;
 //---------------------------------------------------------------------------------
 /*                              Common_n_W*/  int      Common_n_W_;
 /*                              Common_n_W*/  TBranch *Common_n_W_branch;
@@ -637,6 +1001,26 @@ void LoadAllBranches();
 //---------------------------------------------------------------------------------
 /*              Common_btagWeight_DeepCSVB*/  const float &Common_btagWeight_DeepCSVB();
 //---------------------------------------------------------------------------------
+/*                              Common_wgt*/  const float &Common_wgt();
+//---------------------------------------------------------------------------------
+/*                   Common_event_puWeight*/  const float &Common_event_puWeight();
+//---------------------------------------------------------------------------------
+/*                 Common_event_puWeightup*/  const float &Common_event_puWeightup();
+//---------------------------------------------------------------------------------
+/*                 Common_event_puWeightdn*/  const float &Common_event_puWeightdn();
+//---------------------------------------------------------------------------------
+/*              Common_event_prefireWeight*/  const float &Common_event_prefireWeight();
+//---------------------------------------------------------------------------------
+/*            Common_event_prefireWeightup*/  const float &Common_event_prefireWeightup();
+//---------------------------------------------------------------------------------
+/*            Common_event_prefireWeightdn*/  const float &Common_event_prefireWeightdn();
+//---------------------------------------------------------------------------------
+/*              Common_event_triggerWeight*/  const float &Common_event_triggerWeight();
+//---------------------------------------------------------------------------------
+/*            Common_event_triggerWeightup*/  const float &Common_event_triggerWeightup();
+//---------------------------------------------------------------------------------
+/*            Common_event_triggerWeightdn*/  const float &Common_event_triggerWeightdn();
+//---------------------------------------------------------------------------------
 /*         Common_LHEWeight_mg_reweighting*/  const vector<float> &Common_LHEWeight_mg_reweighting();
 //---------------------------------------------------------------------------------
 /*Common_HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ*/  const bool &Common_HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ();
@@ -657,6 +1041,26 @@ void LoadAllBranches();
 //---------------------------------------------------------------------------------
 /*Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL*/  const bool &Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL();
 //---------------------------------------------------------------------------------
+/*                     Common_HLT_PFHT1050*/  const bool &Common_HLT_PFHT1050();
+//---------------------------------------------------------------------------------
+/*                  Common_HLT_AK8PFJet500*/  const bool &Common_HLT_AK8PFJet500();
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet380_TrimMass30*/  const bool &Common_HLT_AK8PFJet380_TrimMass30();
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet360_TrimMass30*/  const bool &Common_HLT_AK8PFJet360_TrimMass30();
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet400_TrimMass30*/  const bool &Common_HLT_AK8PFJet400_TrimMass30();
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet420_TrimMass30*/  const bool &Common_HLT_AK8PFJet420_TrimMass30();
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT750_TrimMass50*/  const bool &Common_HLT_AK8PFHT750_TrimMass50();
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT800_TrimMass50*/  const bool &Common_HLT_AK8PFHT800_TrimMass50();
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT850_TrimMass50*/  const bool &Common_HLT_AK8PFHT850_TrimMass50();
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT900_TrimMass50*/  const bool &Common_HLT_AK8PFHT900_TrimMass50();
+//---------------------------------------------------------------------------------
 /*                     Common_HLT_DoubleEl*/  const bool &Common_HLT_DoubleEl();
 //---------------------------------------------------------------------------------
 /*                         Common_HLT_MuEG*/  const bool &Common_HLT_MuEG();
@@ -675,6 +1079,14 @@ void LoadAllBranches();
 //---------------------------------------------------------------------------------
 /*                           Common_met_p4*/  const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &Common_met_p4();
 //---------------------------------------------------------------------------------
+/*                     Common_met_p4_jesup*/  const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &Common_met_p4_jesup();
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jesdn*/  const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &Common_met_p4_jesdn();
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jerup*/  const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &Common_met_p4_jerup();
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jerdn*/  const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &Common_met_p4_jerdn();
+//---------------------------------------------------------------------------------
 /*                      Common_event_lepSF*/  const float &Common_event_lepSF();
 //---------------------------------------------------------------------------------
 /*                  Common_event_lepSFelup*/  const float &Common_event_lepSFelup();
@@ -684,6 +1096,58 @@ void LoadAllBranches();
 /*                  Common_event_lepSFmuup*/  const float &Common_event_lepSFmuup();
 //---------------------------------------------------------------------------------
 /*                  Common_event_lepSFmudn*/  const float &Common_event_lepSFmudn();
+//---------------------------------------------------------------------------------
+/*                 Common_event_lepSFTight*/  const float &Common_event_lepSFTight();
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFelupTight*/  const float &Common_event_lepSFelupTight();
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFeldnTight*/  const float &Common_event_lepSFeldnTight();
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFmuupTight*/  const float &Common_event_lepSFmuupTight();
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFmudnTight*/  const float &Common_event_lepSFmudnTight();
+//---------------------------------------------------------------------------------
+/*                Common_event_tightBtagSF*/  const float &Common_event_tightBtagSF();
+//---------------------------------------------------------------------------------
+/*              Common_event_tightBtagSFup*/  const float &Common_event_tightBtagSFup();
+//---------------------------------------------------------------------------------
+/*              Common_event_tightBtagSFdn*/  const float &Common_event_tightBtagSFdn();
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFHFup*/  const float &Common_event_tightBtagSFHFup();
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFHFdn*/  const float &Common_event_tightBtagSFHFdn();
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFLFup*/  const float &Common_event_tightBtagSFLFup();
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFLFdn*/  const float &Common_event_tightBtagSFLFdn();
+//---------------------------------------------------------------------------------
+/*               Common_event_mediumBtagSF*/  const float &Common_event_mediumBtagSF();
+//---------------------------------------------------------------------------------
+/*             Common_event_mediumBtagSFup*/  const float &Common_event_mediumBtagSFup();
+//---------------------------------------------------------------------------------
+/*             Common_event_mediumBtagSFdn*/  const float &Common_event_mediumBtagSFdn();
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFHFup*/  const float &Common_event_mediumBtagSFHFup();
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFHFdn*/  const float &Common_event_mediumBtagSFHFdn();
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFLFup*/  const float &Common_event_mediumBtagSFLFup();
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFLFdn*/  const float &Common_event_mediumBtagSFLFdn();
+//---------------------------------------------------------------------------------
+/*                Common_event_looseBtagSF*/  const float &Common_event_looseBtagSF();
+//---------------------------------------------------------------------------------
+/*              Common_event_looseBtagSFup*/  const float &Common_event_looseBtagSFup();
+//---------------------------------------------------------------------------------
+/*              Common_event_looseBtagSFdn*/  const float &Common_event_looseBtagSFdn();
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFHFup*/  const float &Common_event_looseBtagSFHFup();
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFHFdn*/  const float &Common_event_looseBtagSFHFdn();
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFLFup*/  const float &Common_event_looseBtagSFLFup();
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFLFdn*/  const float &Common_event_looseBtagSFLFdn();
 //---------------------------------------------------------------------------------
 /*                           Common_lep_p4*/  const vector<ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > > &Common_lep_p4();
 //---------------------------------------------------------------------------------
@@ -723,11 +1187,31 @@ void LoadAllBranches();
 //---------------------------------------------------------------------------------
 /*                   Common_jet_passBtight*/  const vector<bool> &Common_jet_passBtight();
 //---------------------------------------------------------------------------------
+/*                           Common_jet_id*/  const vector<int> &Common_jet_id();
+//---------------------------------------------------------------------------------
 /*                Common_jet_overlapfatjet*/  const vector<int> &Common_jet_overlapfatjet();
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jesup*/  const vector<float> &Common_jet_pt_jesup();
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jesdn*/  const vector<float> &Common_jet_pt_jesdn();
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jerup*/  const vector<float> &Common_jet_pt_jerup();
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jerdn*/  const vector<float> &Common_jet_pt_jerdn();
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jesup*/  const vector<float> &Common_jet_mass_jesup();
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jesdn*/  const vector<float> &Common_jet_mass_jesdn();
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jerup*/  const vector<float> &Common_jet_mass_jerup();
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jerdn*/  const vector<float> &Common_jet_mass_jerdn();
 //---------------------------------------------------------------------------------
 /*                        Common_fatjet_p4*/  const vector<ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > > &Common_fatjet_p4();
 //---------------------------------------------------------------------------------
 /*                      Common_fatjet_idxs*/  const vector<int> &Common_fatjet_idxs();
+//---------------------------------------------------------------------------------
+/*                        Common_fatjet_id*/  const vector<int> &Common_fatjet_id();
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_msoftdrop*/  const vector<float> &Common_fatjet_msoftdrop();
 //---------------------------------------------------------------------------------
@@ -744,6 +1228,24 @@ void LoadAllBranches();
 /*                    Common_fatjet_deep_T*/  const vector<float> &Common_fatjet_deep_T();
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_deepMD_bb*/  const vector<float> &Common_fatjet_deepMD_bb();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_particleNetMD_W*/  const vector<float> &Common_fatjet_particleNetMD_W();
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xqq*/  const vector<float> &Common_fatjet_particleNetMD_Xqq();
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xcc*/  const vector<float> &Common_fatjet_particleNetMD_Xcc();
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xbb*/  const vector<float> &Common_fatjet_particleNetMD_Xbb();
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_QCD*/  const vector<float> &Common_fatjet_particleNetMD_QCD();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_particleNet_QCD*/  const vector<float> &Common_fatjet_particleNet_QCD();
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_W*/  const vector<float> &Common_fatjet_particleNet_W();
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_Z*/  const vector<float> &Common_fatjet_particleNet_Z();
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_T*/  const vector<float> &Common_fatjet_particleNet_T();
 //---------------------------------------------------------------------------------
 /*                      Common_fatjet_tau3*/  const vector<float> &Common_fatjet_tau3();
 //---------------------------------------------------------------------------------
@@ -777,6 +1279,8 @@ void LoadAllBranches();
 //---------------------------------------------------------------------------------
 /*                        Common_fatjet_WP*/  const vector<int> &Common_fatjet_WP();
 //---------------------------------------------------------------------------------
+/*                     Common_fatjet_WP_MD*/  const vector<int> &Common_fatjet_WP_MD();
+//---------------------------------------------------------------------------------
 /*            Common_fatjet_WP_antimasscut*/  const vector<int> &Common_fatjet_WP_antimasscut();
 //---------------------------------------------------------------------------------
 /*                  Common_fatjet_SFVLoose*/  const vector<float> &Common_fatjet_SFVLoose();
@@ -802,6 +1306,46 @@ void LoadAllBranches();
 /*                Common_fatjet_SFupMedium*/  const vector<float> &Common_fatjet_SFupMedium();
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_SFupTight*/  const vector<float> &Common_fatjet_SFupTight();
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jesup*/  const vector<float> &Common_fatjet_pt_jesup();
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jesdn*/  const vector<float> &Common_fatjet_pt_jesdn();
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jerup*/  const vector<float> &Common_fatjet_pt_jerup();
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jerdn*/  const vector<float> &Common_fatjet_pt_jerdn();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jesup*/  const vector<float> &Common_fatjet_msoftdrop_jesup();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jesdn*/  const vector<float> &Common_fatjet_msoftdrop_jesdn();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jerup*/  const vector<float> &Common_fatjet_msoftdrop_jerup();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jerdn*/  const vector<float> &Common_fatjet_msoftdrop_jerdn();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmsup*/  const vector<float> &Common_fatjet_msoftdrop_jmsup();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmsdn*/  const vector<float> &Common_fatjet_msoftdrop_jmsdn();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmrup*/  const vector<float> &Common_fatjet_msoftdrop_jmrup();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmrdn*/  const vector<float> &Common_fatjet_msoftdrop_jmrdn();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jesup*/  const vector<float> &Common_fatjet_mass_jesup();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jesdn*/  const vector<float> &Common_fatjet_mass_jesdn();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jerup*/  const vector<float> &Common_fatjet_mass_jerup();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jerdn*/  const vector<float> &Common_fatjet_mass_jerdn();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmsup*/  const vector<float> &Common_fatjet_mass_jmsup();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmsdn*/  const vector<float> &Common_fatjet_mass_jmsdn();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmrup*/  const vector<float> &Common_fatjet_mass_jmrup();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmrdn*/  const vector<float> &Common_fatjet_mass_jmrdn();
 //---------------------------------------------------------------------------------
 /*      Common_eventweight_fatjet_SFVLoose*/  const float &Common_eventweight_fatjet_SFVLoose();
 //---------------------------------------------------------------------------------
@@ -854,6 +1398,8 @@ void LoadAllBranches();
 /*                 Common_gen_vvvdecay_p4s*/  const vector<ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > > &Common_gen_vvvdecay_p4s();
 //---------------------------------------------------------------------------------
 /*          Common_gen_vvvdecay_taudecayid*/  const vector<int> &Common_gen_vvvdecay_taudecayid();
+//---------------------------------------------------------------------------------
+/*                         Common_isSignal*/  const bool &Common_isSignal();
 //---------------------------------------------------------------------------------
 /*                              Common_n_W*/  const int &Common_n_W();
 //---------------------------------------------------------------------------------
@@ -945,6 +1491,26 @@ namespace tas {
 //---------------------------------------------------------------------------------
 /*              Common_btagWeight_DeepCSVB*/  const float &Common_btagWeight_DeepCSVB();
 //---------------------------------------------------------------------------------
+/*                              Common_wgt*/  const float &Common_wgt();
+//---------------------------------------------------------------------------------
+/*                   Common_event_puWeight*/  const float &Common_event_puWeight();
+//---------------------------------------------------------------------------------
+/*                 Common_event_puWeightup*/  const float &Common_event_puWeightup();
+//---------------------------------------------------------------------------------
+/*                 Common_event_puWeightdn*/  const float &Common_event_puWeightdn();
+//---------------------------------------------------------------------------------
+/*              Common_event_prefireWeight*/  const float &Common_event_prefireWeight();
+//---------------------------------------------------------------------------------
+/*            Common_event_prefireWeightup*/  const float &Common_event_prefireWeightup();
+//---------------------------------------------------------------------------------
+/*            Common_event_prefireWeightdn*/  const float &Common_event_prefireWeightdn();
+//---------------------------------------------------------------------------------
+/*              Common_event_triggerWeight*/  const float &Common_event_triggerWeight();
+//---------------------------------------------------------------------------------
+/*            Common_event_triggerWeightup*/  const float &Common_event_triggerWeightup();
+//---------------------------------------------------------------------------------
+/*            Common_event_triggerWeightdn*/  const float &Common_event_triggerWeightdn();
+//---------------------------------------------------------------------------------
 /*         Common_LHEWeight_mg_reweighting*/  const vector<float> &Common_LHEWeight_mg_reweighting();
 //---------------------------------------------------------------------------------
 /*Common_HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ*/  const bool &Common_HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ();
@@ -965,6 +1531,26 @@ namespace tas {
 //---------------------------------------------------------------------------------
 /*Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL*/  const bool &Common_HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL();
 //---------------------------------------------------------------------------------
+/*                     Common_HLT_PFHT1050*/  const bool &Common_HLT_PFHT1050();
+//---------------------------------------------------------------------------------
+/*                  Common_HLT_AK8PFJet500*/  const bool &Common_HLT_AK8PFJet500();
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet380_TrimMass30*/  const bool &Common_HLT_AK8PFJet380_TrimMass30();
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet360_TrimMass30*/  const bool &Common_HLT_AK8PFJet360_TrimMass30();
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet400_TrimMass30*/  const bool &Common_HLT_AK8PFJet400_TrimMass30();
+//---------------------------------------------------------------------------------
+/*       Common_HLT_AK8PFJet420_TrimMass30*/  const bool &Common_HLT_AK8PFJet420_TrimMass30();
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT750_TrimMass50*/  const bool &Common_HLT_AK8PFHT750_TrimMass50();
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT800_TrimMass50*/  const bool &Common_HLT_AK8PFHT800_TrimMass50();
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT850_TrimMass50*/  const bool &Common_HLT_AK8PFHT850_TrimMass50();
+//---------------------------------------------------------------------------------
+/*        Common_HLT_AK8PFHT900_TrimMass50*/  const bool &Common_HLT_AK8PFHT900_TrimMass50();
+//---------------------------------------------------------------------------------
 /*                     Common_HLT_DoubleEl*/  const bool &Common_HLT_DoubleEl();
 //---------------------------------------------------------------------------------
 /*                         Common_HLT_MuEG*/  const bool &Common_HLT_MuEG();
@@ -983,6 +1569,14 @@ namespace tas {
 //---------------------------------------------------------------------------------
 /*                           Common_met_p4*/  const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &Common_met_p4();
 //---------------------------------------------------------------------------------
+/*                     Common_met_p4_jesup*/  const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &Common_met_p4_jesup();
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jesdn*/  const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &Common_met_p4_jesdn();
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jerup*/  const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &Common_met_p4_jerup();
+//---------------------------------------------------------------------------------
+/*                     Common_met_p4_jerdn*/  const ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > &Common_met_p4_jerdn();
+//---------------------------------------------------------------------------------
 /*                      Common_event_lepSF*/  const float &Common_event_lepSF();
 //---------------------------------------------------------------------------------
 /*                  Common_event_lepSFelup*/  const float &Common_event_lepSFelup();
@@ -992,6 +1586,58 @@ namespace tas {
 /*                  Common_event_lepSFmuup*/  const float &Common_event_lepSFmuup();
 //---------------------------------------------------------------------------------
 /*                  Common_event_lepSFmudn*/  const float &Common_event_lepSFmudn();
+//---------------------------------------------------------------------------------
+/*                 Common_event_lepSFTight*/  const float &Common_event_lepSFTight();
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFelupTight*/  const float &Common_event_lepSFelupTight();
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFeldnTight*/  const float &Common_event_lepSFeldnTight();
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFmuupTight*/  const float &Common_event_lepSFmuupTight();
+//---------------------------------------------------------------------------------
+/*             Common_event_lepSFmudnTight*/  const float &Common_event_lepSFmudnTight();
+//---------------------------------------------------------------------------------
+/*                Common_event_tightBtagSF*/  const float &Common_event_tightBtagSF();
+//---------------------------------------------------------------------------------
+/*              Common_event_tightBtagSFup*/  const float &Common_event_tightBtagSFup();
+//---------------------------------------------------------------------------------
+/*              Common_event_tightBtagSFdn*/  const float &Common_event_tightBtagSFdn();
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFHFup*/  const float &Common_event_tightBtagSFHFup();
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFHFdn*/  const float &Common_event_tightBtagSFHFdn();
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFLFup*/  const float &Common_event_tightBtagSFLFup();
+//---------------------------------------------------------------------------------
+/*            Common_event_tightBtagSFLFdn*/  const float &Common_event_tightBtagSFLFdn();
+//---------------------------------------------------------------------------------
+/*               Common_event_mediumBtagSF*/  const float &Common_event_mediumBtagSF();
+//---------------------------------------------------------------------------------
+/*             Common_event_mediumBtagSFup*/  const float &Common_event_mediumBtagSFup();
+//---------------------------------------------------------------------------------
+/*             Common_event_mediumBtagSFdn*/  const float &Common_event_mediumBtagSFdn();
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFHFup*/  const float &Common_event_mediumBtagSFHFup();
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFHFdn*/  const float &Common_event_mediumBtagSFHFdn();
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFLFup*/  const float &Common_event_mediumBtagSFLFup();
+//---------------------------------------------------------------------------------
+/*           Common_event_mediumBtagSFLFdn*/  const float &Common_event_mediumBtagSFLFdn();
+//---------------------------------------------------------------------------------
+/*                Common_event_looseBtagSF*/  const float &Common_event_looseBtagSF();
+//---------------------------------------------------------------------------------
+/*              Common_event_looseBtagSFup*/  const float &Common_event_looseBtagSFup();
+//---------------------------------------------------------------------------------
+/*              Common_event_looseBtagSFdn*/  const float &Common_event_looseBtagSFdn();
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFHFup*/  const float &Common_event_looseBtagSFHFup();
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFHFdn*/  const float &Common_event_looseBtagSFHFdn();
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFLFup*/  const float &Common_event_looseBtagSFLFup();
+//---------------------------------------------------------------------------------
+/*            Common_event_looseBtagSFLFdn*/  const float &Common_event_looseBtagSFLFdn();
 //---------------------------------------------------------------------------------
 /*                           Common_lep_p4*/  const vector<ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > > &Common_lep_p4();
 //---------------------------------------------------------------------------------
@@ -1031,11 +1677,31 @@ namespace tas {
 //---------------------------------------------------------------------------------
 /*                   Common_jet_passBtight*/  const vector<bool> &Common_jet_passBtight();
 //---------------------------------------------------------------------------------
+/*                           Common_jet_id*/  const vector<int> &Common_jet_id();
+//---------------------------------------------------------------------------------
 /*                Common_jet_overlapfatjet*/  const vector<int> &Common_jet_overlapfatjet();
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jesup*/  const vector<float> &Common_jet_pt_jesup();
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jesdn*/  const vector<float> &Common_jet_pt_jesdn();
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jerup*/  const vector<float> &Common_jet_pt_jerup();
+//---------------------------------------------------------------------------------
+/*                     Common_jet_pt_jerdn*/  const vector<float> &Common_jet_pt_jerdn();
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jesup*/  const vector<float> &Common_jet_mass_jesup();
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jesdn*/  const vector<float> &Common_jet_mass_jesdn();
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jerup*/  const vector<float> &Common_jet_mass_jerup();
+//---------------------------------------------------------------------------------
+/*                   Common_jet_mass_jerdn*/  const vector<float> &Common_jet_mass_jerdn();
 //---------------------------------------------------------------------------------
 /*                        Common_fatjet_p4*/  const vector<ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > > &Common_fatjet_p4();
 //---------------------------------------------------------------------------------
 /*                      Common_fatjet_idxs*/  const vector<int> &Common_fatjet_idxs();
+//---------------------------------------------------------------------------------
+/*                        Common_fatjet_id*/  const vector<int> &Common_fatjet_id();
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_msoftdrop*/  const vector<float> &Common_fatjet_msoftdrop();
 //---------------------------------------------------------------------------------
@@ -1052,6 +1718,24 @@ namespace tas {
 /*                    Common_fatjet_deep_T*/  const vector<float> &Common_fatjet_deep_T();
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_deepMD_bb*/  const vector<float> &Common_fatjet_deepMD_bb();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_particleNetMD_W*/  const vector<float> &Common_fatjet_particleNetMD_W();
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xqq*/  const vector<float> &Common_fatjet_particleNetMD_Xqq();
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xcc*/  const vector<float> &Common_fatjet_particleNetMD_Xcc();
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_Xbb*/  const vector<float> &Common_fatjet_particleNetMD_Xbb();
+//---------------------------------------------------------------------------------
+/*         Common_fatjet_particleNetMD_QCD*/  const vector<float> &Common_fatjet_particleNetMD_QCD();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_particleNet_QCD*/  const vector<float> &Common_fatjet_particleNet_QCD();
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_W*/  const vector<float> &Common_fatjet_particleNet_W();
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_Z*/  const vector<float> &Common_fatjet_particleNet_Z();
+//---------------------------------------------------------------------------------
+/*             Common_fatjet_particleNet_T*/  const vector<float> &Common_fatjet_particleNet_T();
 //---------------------------------------------------------------------------------
 /*                      Common_fatjet_tau3*/  const vector<float> &Common_fatjet_tau3();
 //---------------------------------------------------------------------------------
@@ -1085,6 +1769,8 @@ namespace tas {
 //---------------------------------------------------------------------------------
 /*                        Common_fatjet_WP*/  const vector<int> &Common_fatjet_WP();
 //---------------------------------------------------------------------------------
+/*                     Common_fatjet_WP_MD*/  const vector<int> &Common_fatjet_WP_MD();
+//---------------------------------------------------------------------------------
 /*            Common_fatjet_WP_antimasscut*/  const vector<int> &Common_fatjet_WP_antimasscut();
 //---------------------------------------------------------------------------------
 /*                  Common_fatjet_SFVLoose*/  const vector<float> &Common_fatjet_SFVLoose();
@@ -1110,6 +1796,46 @@ namespace tas {
 /*                Common_fatjet_SFupMedium*/  const vector<float> &Common_fatjet_SFupMedium();
 //---------------------------------------------------------------------------------
 /*                 Common_fatjet_SFupTight*/  const vector<float> &Common_fatjet_SFupTight();
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jesup*/  const vector<float> &Common_fatjet_pt_jesup();
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jesdn*/  const vector<float> &Common_fatjet_pt_jesdn();
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jerup*/  const vector<float> &Common_fatjet_pt_jerup();
+//---------------------------------------------------------------------------------
+/*                  Common_fatjet_pt_jerdn*/  const vector<float> &Common_fatjet_pt_jerdn();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jesup*/  const vector<float> &Common_fatjet_msoftdrop_jesup();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jesdn*/  const vector<float> &Common_fatjet_msoftdrop_jesdn();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jerup*/  const vector<float> &Common_fatjet_msoftdrop_jerup();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jerdn*/  const vector<float> &Common_fatjet_msoftdrop_jerdn();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmsup*/  const vector<float> &Common_fatjet_msoftdrop_jmsup();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmsdn*/  const vector<float> &Common_fatjet_msoftdrop_jmsdn();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmrup*/  const vector<float> &Common_fatjet_msoftdrop_jmrup();
+//---------------------------------------------------------------------------------
+/*           Common_fatjet_msoftdrop_jmrdn*/  const vector<float> &Common_fatjet_msoftdrop_jmrdn();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jesup*/  const vector<float> &Common_fatjet_mass_jesup();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jesdn*/  const vector<float> &Common_fatjet_mass_jesdn();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jerup*/  const vector<float> &Common_fatjet_mass_jerup();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jerdn*/  const vector<float> &Common_fatjet_mass_jerdn();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmsup*/  const vector<float> &Common_fatjet_mass_jmsup();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmsdn*/  const vector<float> &Common_fatjet_mass_jmsdn();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmrup*/  const vector<float> &Common_fatjet_mass_jmrup();
+//---------------------------------------------------------------------------------
+/*                Common_fatjet_mass_jmrdn*/  const vector<float> &Common_fatjet_mass_jmrdn();
 //---------------------------------------------------------------------------------
 /*      Common_eventweight_fatjet_SFVLoose*/  const float &Common_eventweight_fatjet_SFVLoose();
 //---------------------------------------------------------------------------------
@@ -1162,6 +1888,8 @@ namespace tas {
 /*                 Common_gen_vvvdecay_p4s*/  const vector<ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > > &Common_gen_vvvdecay_p4s();
 //---------------------------------------------------------------------------------
 /*          Common_gen_vvvdecay_taudecayid*/  const vector<int> &Common_gen_vvvdecay_taudecayid();
+//---------------------------------------------------------------------------------
+/*                         Common_isSignal*/  const bool &Common_isSignal();
 //---------------------------------------------------------------------------------
 /*                              Common_n_W*/  const int &Common_n_W();
 //---------------------------------------------------------------------------------


### PR DESCRIPTION
Add computed ParticleNetMD branches, add preliminary WPs from here: https://indico.cern.ch/event/1103765/contributions/4647556/attachments/2364610/4037250/ParticleNet_2018_ULNanoV9_JMAR_14Dec2021_PK.pdf
Did not add preliminary fatjet SFs, which are also in this talk.

I also added some missing hadronic triggers and updates to the allHadronic code, but this should be transparent to others.